### PR TITLE
Fix Android data

### DIFF
--- a/src/sentry.android.ts
+++ b/src/sentry.android.ts
@@ -93,7 +93,9 @@ export class Sentry {
     nativeUser.setId(user.id);
     nativeUser.setEmail(user.email ? user.email : '');
     nativeUser.setUsername(user.username ? user.username : '');
-    nativeUser.setOthers(nativeMapObject ? nativeMapObject : null);
+    if (nativeMapObject) {
+      nativeUser.setOthers(nativeMapObject);
+    }
     io.sentry.core.Sentry.setUser(nativeUser);
   }
 


### PR DESCRIPTION
This fixes a bug in the 2.0.0 version, when you use `setContextUser(user)`, and don't set the `data` property of the user, you get an exception: 
`java.lang.NullPointerException: Attempt to invoke interface method 'int java.util.Map.size()' on a null object reference`

This is due to sentry-java converting the hashmap to a ConcurrentHashMap that is used in `setOthers()`: https://github.com/getsentry/sentry-java/blob/5ebd49cbfd17eb66175e9247db6d27e4df84a56b/sentry/src/main/java/io/sentry/protocol/User.java#L120

When we give null, there is nothing to convert so it errors out. We can fix this by not executing `setOthers()` when we don't have extra data. We could also fix this by always creating as `HashMap` in `nativeMapObject`, but this seems to be a better fix to me.