### PR TITLE
Upgrade Sentry, unify Android and iOS usage of init and add ability to initialize with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ns plugin add nativescript-sentry
 Add the following line to your `AndroidManifest.xml` within the `<application>-tag`:
 
 ```xml
-<meta-data android:name="io.sentry.dsn" android:value="__YOUR_DSN_HERE__" />
+<meta-data android:name="io.sentry.auto-init" android:value="false" />
 ```
 
 ### Without Angular
@@ -127,7 +127,7 @@ export interface BreadCrumb {
 ### Set user
 
 ```typescript
-Sentry.setContextUser(user: SentryUser)
+Sentry.setUser(user: SentryUser)
 ```
 
 ```typescript
@@ -141,13 +141,13 @@ export interface SentryUser {
 ### Set tags
 
 ```typescript
-Sentry.setContextTags(tags: object)
+Sentry.setTags(tags: object)
 ```
 
 ### Set extra information
 
 ```typescript
-Sentry.setContextExtra(extra: object)
+Sentry.setExtras(extra: object)
 ```
 
 ### Clear context (user, tags, extra information)

--- a/demo/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/demo/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
 		android:label="@string/app_name"
 		android:theme="@style/AppTheme">
 
-		<meta-data android:name="io.sentry.dsn" android:value="__YOUR_DSN_HERE__" />
+		<meta-data android:name="io.sentry.auto-init" android:value="false" />
 
 		<activity
 			android:name="com.tns.NativeScriptActivity"

--- a/demo/app/app.ts
+++ b/demo/app/app.ts
@@ -7,7 +7,8 @@ purpose of the file is to pass control to the app’s first module.
 import { Application } from '@nativescript/core';
 import { Sentry } from 'nativescript-sentry';
 
-Sentry.init('__YOUR_DSN_HERE__');
+// Sentry.init('__YOUR_DSN_HERE__');
+Sentry.initWithOptions({dsn: '__YOUR_DSN_HERE__', release: '2.4.0', environment: 'development'});
 
 Application.run({ moduleName: 'app-root' });
 

--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -14,17 +14,13 @@ export function pageLoaded(args: EventData) {
 }
 
 export function setSentryUser() {
-  Sentry.setContextUser({
+  Sentry.setUser({
     id: '19210029akd01jjd9102',
     email: obsData.get('user_email'),
     data: {
       bool_value: false,
       string_value: 'test string',
-      number_value: 35,
-      created: {
-        date: 'January 1, 1999',
-        picture_url: 'https://docs.sentry.io/'
-      }
+      number_value: 35
     }
   });
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,12 +1,12 @@
 {
   "dependencies": {
-    "@nativescript/core": "7.0.0",
+    "@nativescript/core": "7.3.0",
     "@nativescript/theme": "^2.5.0",
     "nativescript-sentry": "file:../src",
     "nativescript-unit-test-runner": "^0.7.0"
   },
   "devDependencies": {
-    "@nativescript/android": "7.0.0",
+    "@nativescript/android": "7.0.1",
     "@nativescript/ios": "7.2.0",
     "@nativescript/types": "^7.3.0",
     "@nativescript/webpack": "^3.0.9",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -99,17 +99,38 @@ export abstract class Sentry {
    * Set a user to the Sentry context.
    * @param user [SentryUser] - The user to set with the current Sentry context.
    */
-  static setContextUser(user: SentryUser): void;
+  static setUser(user: User): void;
+
+  /**
+   * Set a user to the Sentry context.
+   * @param user [SentryUser] - The user to set with the current Sentry context.
+   * @deprecated Use setUser instead.
+   */
+  static setContextUser(user: User): void;
 
   /**
    * Set an object of additional Key/value pairs which generate breakdowns charts and search filters.
    * @param tags [object] - Object of additional Key/value pairs.
+   */
+  static setTags(tags: object): void;
+
+  /**
+   * Set an object of additional Key/value pairs which generate breakdowns charts and search filters.
+   * @param tags [object] - Object of additional Key/value pairs.
+   * @deprecated Use setTags instead.
    */
   static setContextTags(tags: object): void;
 
   /**
    * Set an object of unstructured data which is stored with events for the current Sentry context.
    * @param extra [object] - An arbitrary object of Key/value pairs.
+   */
+  static setExtras(extra: object): void;
+
+  /**
+   * Set an object of unstructured data which is stored with events for the current Sentry context.
+   * @param extra [object] - An arbitrary object of Key/value pairs.
+   * @deprecated Use setExtras instead.
    */
   static setContextExtra(extra: object): void;
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -45,12 +45,35 @@ export interface ExceptionOptions {
   extra?: object;
 }
 
+export interface SentryInitOptions {
+  /**
+   * The client DSN key for the Sentry project.
+   */
+  dsn: string;
+
+  /**
+   * [optional] The environment to tag all events with.
+   */
+  environment?: string;
+
+  /**
+   * [optional] The release to tag all events with.
+   */
+  release?: string;
+}
+
 export abstract class Sentry {
   /**
    * Initializes the Sentry SDK for the provided DSN key.
    * @param dsn [string] - The client DSN key for the Sentry project.
    */
   static init(dsn: string): void;
+
+  /**
+   * Initializes the Sentry SDK with the provided options.
+   * @param options [SentryInitOptions] - The Sentry options to initialize with.
+   */
+  static initWithOptions(options: SentryInitOptions): void;
 
   /**
    * Log a message.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,7 @@ export enum Level {
   Debug = 'debug'
 }
 
-export interface SentryUser {
+export interface User {
   id: string;
   email?: string;
   username?: string;

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1825,15 +1825,6 @@
         }
       }
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
@@ -3068,15 +3059,6 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
-    "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
-    },
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
@@ -3852,12 +3834,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yaml": {

--- a/src/package.json
+++ b/src/package.json
@@ -89,7 +89,6 @@
     "prettier": "^2.2.1",
     "prompt": "^1.1.0",
     "rimraf": "^3.0.0",
-    "semver": "^7.3.5",
     "tslint": "^6.1.3",
     "typescript": "^3.9.9",
     "zone.js": "^0.10.3"
@@ -106,6 +105,5 @@
       "pre-push": "npm run tslint"
     }
   },
-  "bootstrapper": "nativescript-plugin-seed",
-  "dependencies": {}
+  "bootstrapper": "nativescript-plugin-seed"
 }

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -1,13 +1,15 @@
 /* Include.gradle configuration: http://docs.nativescript.org/plugins/plugins#includegradle-specification */
 android {
-
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
 }
 
-// ADD JCENTER REPOSITORY
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    implementation 'io.sentry:sentry-android:2.3.1'
+    implementation 'io.sentry:sentry-android:4.3.0'
 }

--- a/src/platforms/ios/PodFile
+++ b/src/platforms/ios/PodFile
@@ -1,1 +1,1 @@
-pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '4.5.0'
+pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '6.2.1'

--- a/src/scripts/build-native.js
+++ b/src/scripts/build-native.js
@@ -1,24 +1,9 @@
 const { exec } = require('child_process');
-const semver = require('semver');
 
-exec('ns --version', (err, stdout) => {
-    if (err) {
-        // node couldn't execute the command
-        console.log(`ns --version err: ${err}`);
-        return;
-    }
-
-    const tnsVersion = semver.major(stdout);
-
-    // execute 'tns plugin build' for {N} version > 4. This command builds .aar in platforms/android folder.
-    if (tnsVersion >= 4) {
-        console.log(`executing 'ns plugin build'`);
-        exec('ns plugin build', (err) => {
-            if (err) {
-                // node couldn't execute the command
-                console.log(`${err}`);
-                return;
-            }
-        });
-    }
+exec('ns plugin build', err => {
+  if (err) {
+    // node couldn't execute the command
+    console.log(`${err}`);
+    return;
+  }
 });

--- a/src/sentry.android.d.ts
+++ b/src/sentry.android.d.ts
@@ -1,10 +1,13 @@
-import { BreadCrumb, ExceptionOptions, MessageOptions, SentryUser } from './';
+import { BreadCrumb, ExceptionOptions, MessageOptions, SentryInitOptions, User } from './';
 export declare class Sentry {
     static init(dsn: string): void;
+    static initWithOptions(options: SentryInitOptions): void;
     static captureMessage(message: string, options?: MessageOptions): void;
     static captureException(exception: Error, options?: ExceptionOptions): void;
     static captureBreadcrumb(breadcrumb: BreadCrumb): void;
-    static setContextUser(user: SentryUser): void;
+    static setUser(user: User): void;
+    static setContextUser(user: User): void;
+    static setTags(tags: object): void;
     static setContextTags(tags: object): void;
     static setContextExtra(extra: object): void;
     static clearContext(): void;

--- a/src/sentry.android.d.ts
+++ b/src/sentry.android.d.ts
@@ -9,6 +9,7 @@ export declare class Sentry {
     static setContextUser(user: User): void;
     static setTags(tags: object): void;
     static setContextTags(tags: object): void;
+    static setExtras(extras: object): void;
     static setContextExtra(extra: object): void;
     static clearContext(): void;
     private static _convertSentryEventLevel;

--- a/src/sentry.android.ts
+++ b/src/sentry.android.ts
@@ -120,10 +120,13 @@ export class Sentry {
   }
 
   public static clearContext() {
-    // @ts-ignore
-    io.sentry.Sentry.configureScope((scope: io.sentry.Scope) => {
-      scope.clear();
-    });
+    const scopeCallBack = new io.sentry.ScopeCallback({
+      run: (scope) => {
+        scope.clear();
+      }
+    })
+
+    io.sentry.Sentry.configureScope(scopeCallBack);
   }
 
   /**

--- a/src/sentry.android.ts
+++ b/src/sentry.android.ts
@@ -49,11 +49,11 @@ export class Sentry {
   public static captureException(exception: Error, options?: ExceptionOptions) {
     // TODO: attach tags and extra directly on the exeption
     if (options && options.extra) {
-      this.setContextExtra(options.extra);
+      this.setExtras(options.extra);
     }
 
     if (options && options.tags) {
-      this.setContextTags(options.tags);
+      this.setTags(options.tags);
     }
 
     const cause = new java.lang.Throwable(exception.stack);
@@ -111,12 +111,16 @@ export class Sentry {
     this.setTags(tags);
   }
 
-  public static setContextExtra(extra: object) {
-    Object.keys(extra).forEach(key => {
+  public static setExtras(extras: object) {
+    Object.keys(extras).forEach(key => {
       // adding type check to not force toString on the extra
-      const nativeDataValue = Sentry._convertDataTypeToString(extra[key]);
+      const nativeDataValue = Sentry._convertDataTypeToString(extras[key]);
       io.sentry.Sentry.setExtra(key, nativeDataValue);
     });
+  }
+
+  public static setContextExtra(extra: object) {
+    this.setExtras(extra);
   }
 
   public static clearContext() {
@@ -124,7 +128,7 @@ export class Sentry {
       run: (scope) => {
         scope.clear();
       }
-    })
+    });
 
     io.sentry.Sentry.configureScope(scopeCallBack);
   }

--- a/src/sentry.android.ts
+++ b/src/sentry.android.ts
@@ -1,30 +1,28 @@
-import { BreadCrumb, ExceptionOptions, MessageOptions, SentryUser } from './';
-
+import { BreadCrumb, ExceptionOptions, MessageOptions, SentryInitOptions, User } from './';
 export class Sentry {
-  /**
-   * @deprecated - Set your public DSN in your app's AndroidManifest file.
-   * @link https://github.com/FinanzRitter/nativescript-sentry#android for more information
-   * @param dsn
-   */
   public static init(dsn: string) {
-    // Starting with sentry-android 2.0.0 the init method of Sentry does not work out of the box
-    // with NativeScript. This is because it is not possible to call a Java/Kotlin Lambda function
-    // from NativeScript.
-    // Instead configure the DSN and further config in your AndroidManifest.xml.
-    // Add <meta-data android:name="io.sentry.dsn" android:value="__YOUR_DSN_HERE__" /> within the
-    // application tag.
+    this.initWithOptions({dsn});
+  }
+
+  public static initWithOptions(options: SentryInitOptions) {
+    const sentryOptions = new io.sentry.SentryOptions();
+    sentryOptions.setDsn(options.dsn);
+    if (options.environment) sentryOptions.setEnvironment(options.environment);
+    if (options.release) sentryOptions.setRelease(options.release);
+
+    io.sentry.Sentry.init(sentryOptions);
   }
 
   public static captureMessage(message: string, options?: MessageOptions) {
     // Create event
-    const event = new io.sentry.core.SentryEvent();
+    const event = new io.sentry.SentryEvent();
 
     // Set level
     const level = options && options.level ? options.level : null;
     event.setLevel(this._convertSentryEventLevel(level));
 
     // Set message
-    const msg = new io.sentry.core.protocol.Message();
+    const msg = new io.sentry.protocol.Message();
     msg.setMessage(message);
     event.setMessage(msg);
 
@@ -45,7 +43,7 @@ export class Sentry {
     }
 
     // Send event
-    io.sentry.core.Sentry.captureEvent(event);
+    io.sentry.Sentry.captureEvent(event);
   }
 
   public static captureException(exception: Error, options?: ExceptionOptions) {
@@ -64,21 +62,21 @@ export class Sentry {
     // JS Error stacktrace as the "cause" and the JS Error message as the Throwable "message"
     // https://developer.android.com/reference/java/lang/Exception.html#Exception(java.lang.String,%20java.lang.Throwable)
     const ex = new java.lang.Exception(exception.message, cause);
-    io.sentry.core.Sentry.captureException(ex);
+    io.sentry.Sentry.captureException(ex);
   }
 
   public static captureBreadcrumb(breadcrumb: BreadCrumb) {
     // Create BreadCrumb
-    const nativeBreadCrumb = new io.sentry.core.Breadcrumb();
+    const nativeBreadCrumb = new io.sentry.Breadcrumb();
     nativeBreadCrumb.setLevel(this._convertSentryEventLevel(breadcrumb.level));
     nativeBreadCrumb.setCategory(breadcrumb.category);
     nativeBreadCrumb.setMessage(breadcrumb.message);
 
     // Add BreadCrumb
-    io.sentry.core.Sentry.addBreadcrumb(nativeBreadCrumb);
+    io.sentry.Sentry.addBreadcrumb(nativeBreadCrumb);
   }
 
-  public static setContextUser(user: SentryUser) {
+  public static setUser(user: User) {
     // handle the data object if provided
     let nativeMapObject: java.util.HashMap<any, any>;
     if (user.data) {
@@ -89,32 +87,43 @@ export class Sentry {
       });
     }
 
-    const nativeUser = new io.sentry.core.protocol.User();
+    const nativeUser = new io.sentry.protocol.User();
     nativeUser.setId(user.id);
     nativeUser.setEmail(user.email ? user.email : '');
     nativeUser.setUsername(user.username ? user.username : '');
     if (nativeMapObject) {
       nativeUser.setOthers(nativeMapObject);
     }
-    io.sentry.core.Sentry.setUser(nativeUser);
+    io.sentry.Sentry.setUser(nativeUser);
+  }
+
+  public static setContextUser(user: User) {
+    this.setUser(user);
+  }
+
+  public static setTags(tags: object) {
+    Object.keys(tags).forEach(key => {
+      io.sentry.Sentry.setTag(key, tags[key].toString());
+    });
   }
 
   public static setContextTags(tags: object) {
-    Object.keys(tags).forEach(key => {
-      io.sentry.core.Sentry.setTag(key, tags[key].toString());
-    });
+    this.setTags(tags);
   }
 
   public static setContextExtra(extra: object) {
     Object.keys(extra).forEach(key => {
       // adding type check to not force toString on the extra
       const nativeDataValue = Sentry._convertDataTypeToString(extra[key]);
-      io.sentry.core.Sentry.setExtra(key, nativeDataValue);
+      io.sentry.Sentry.setExtra(key, nativeDataValue);
     });
   }
 
   public static clearContext() {
-    // Nothing to do here?
+    // @ts-ignore
+    io.sentry.Sentry.configureScope((scope: io.sentry.Scope) => {
+      scope.clear();
+    });
   }
 
   /**
@@ -122,23 +131,19 @@ export class Sentry {
    * @default - INFO
    */
   private static _convertSentryEventLevel(level: Level) {
-    if (!level) {
-      return io.sentry.core.SentryLevel.INFO;
-    }
-
     switch (level) {
       case Level.Info:
-        return io.sentry.core.SentryLevel.INFO;
+        return io.sentry.SentryLevel.INFO;
       case Level.Warning:
-        return io.sentry.core.SentryLevel.WARNING;
+        return io.sentry.SentryLevel.WARNING;
       case Level.Fatal:
-        return io.sentry.core.SentryLevel.FATAL;
+        return io.sentry.SentryLevel.FATAL;
       case Level.Error:
-        return io.sentry.core.SentryLevel.ERROR;
+        return io.sentry.SentryLevel.ERROR;
       case Level.Debug:
-        return io.sentry.core.SentryLevel.DEBUG;
+        return io.sentry.SentryLevel.DEBUG;
       default:
-        return io.sentry.core.SentryLevel.INFO;
+        return io.sentry.SentryLevel.INFO;
     }
   }
 

--- a/src/sentry.ios.d.ts
+++ b/src/sentry.ios.d.ts
@@ -1,11 +1,15 @@
-import { BreadCrumb, ExceptionOptions, MessageOptions, SentryUser } from './';
+import { BreadCrumb, ExceptionOptions, MessageOptions, SentryInitOptions, User } from './';
 export declare class Sentry {
     static init(dsn: string): void;
+    static initWithOptions(options: SentryInitOptions): void;
     static captureMessage(message: string, options?: MessageOptions): void;
     static captureException(exception: Error, options?: ExceptionOptions): void;
     static captureBreadcrumb(breadcrumb: BreadCrumb): void;
-    static setContextUser(user: SentryUser): void;
+    static setUser(user: User): void;
+    static setContextUser(user: User): void;
+    static setTags(tags: any): void;
     static setContextTags(tags: any): void;
+    static setExtras(extra: any): void;
     static setContextExtra(extra: any): void;
     static clearContext(): void;
     private static _convertSentryLevel;

--- a/src/typings/sentry-api.android.d.ts
+++ b/src/typings/sentry-api.android.d.ts
@@ -1,35 +1,3862 @@
-declare module com {
-	export module google {
-		export module gson {
-			export abstract class TypeAdapter<T>  extends java.lang.Object {
-				public static class: java.lang.Class<com.google.gson.TypeAdapter<any>>;
-				public write(param0: any, param1: T): void;
-				public fromJson(param0: java.io.Reader): T;
-				public toJsonTree(param0: T): any;
-				public toJson(param0: T): string;
-				public nullSafe(): com.google.gson.TypeAdapter<T>;
-				public fromJson(param0: string): T;
-				public toJson(param0: java.io.Writer, param1: T): void;
-				public fromJsonTree(param0: any): T;
-				public read(param0: any): T;
+/// <reference path="android-declarations.d.ts"/>
+
+declare module io {
+	export module sentry {
+		export class AsyncHttpTransportFactory extends io.sentry.ITransportFactory {
+			public static class: java.lang.Class<io.sentry.AsyncHttpTransportFactory>;
+			public constructor();
+			public create(param0: io.sentry.SentryOptions, param1: io.sentry.RequestDetails): io.sentry.transport.ITransport;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class Attachment {
+			public static class: java.lang.Class<io.sentry.Attachment>;
+			public constructor(param0: string, param1: string);
+			public getBytes(): androidNative.Array<number>;
+			public constructor(param0: androidNative.Array<number>, param1: string);
+			public getFilename(): string;
+			public constructor(param0: androidNative.Array<number>, param1: string, param2: string);
+			public getPathname(): string;
+			public constructor(param0: androidNative.Array<number>, param1: string, param2: string, param3: boolean);
+			public constructor(param0: string, param1: string, param2: string);
+			public getContentType(): string;
+			public constructor(param0: string, param1: string, param2: string, param3: boolean);
+			public constructor(param0: string);
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class Breadcrumb extends io.sentry.IUnknownPropertiesConsumer {
+			public static class: java.lang.Class<io.sentry.Breadcrumb>;
+			public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+			public removeData(param0: string): void;
+			public clone(): io.sentry.Breadcrumb;
+			public constructor();
+			public getData(param0: string): any;
+			public getMessage(): string;
+			public setMessage(param0: string): void;
+			public getData(): java.util.Map<string,any>;
+			public setType(param0: string): void;
+			public getLevel(): io.sentry.SentryLevel;
+			public getTimestamp(): java.util.Date;
+			public setData(param0: string, param1: any): void;
+			public setLevel(param0: io.sentry.SentryLevel): void;
+			public constructor(param0: java.util.Date);
+			public setCategory(param0: string): void;
+			public static http(param0: string, param1: string): io.sentry.Breadcrumb;
+			public getType(): string;
+			public constructor(param0: string);
+			public getCategory(): string;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class BuildConfig {
+			public static class: java.lang.Class<io.sentry.BuildConfig>;
+			public static SENTRY_JAVA_SDK_NAME: string;
+			public static VERSION_NAME: string;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class CircularFifoQueue<E>  extends java.util.AbstractCollection<any> {
+			public static class: java.lang.Class<io.sentry.CircularFifoQueue<any>>;
+			public isFull(): boolean;
+			public clear(): void;
+			public size(): number;
+			public isEmpty(): boolean;
+			public poll(): any;
+			public isAtFullCapacity(): boolean;
+			public constructor();
+			public constructor(param0: java.util.Collection<any>);
+			public maxSize(): number;
+			public peek(): any;
+			public offer(param0: any): boolean;
+			public remove(): any;
+			public add(param0: any): boolean;
+			public get(param0: number): any;
+			public element(): any;
+			public iterator(): java.util.Iterator<any>;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class CustomSamplingContext {
+			public static class: java.lang.Class<io.sentry.CustomSamplingContext>;
+			public set(param0: string, param1: any): void;
+			public get(param0: string): any;
+			public getData(): java.util.Map<string,any>;
+			public constructor();
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class DateUtils {
+			public static class: java.lang.Class<io.sentry.DateUtils>;
+			public static getCurrentDateTime(): java.util.Date;
+			public static getDateTimeWithMillisPrecision(param0: string): java.util.Date;
+			public static getDateTime(param0: string): java.util.Date;
+			public static getTimestamp(param0: java.util.Date): string;
+			public static getDateTime(param0: number): java.util.Date;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class DiagnosticLogger extends io.sentry.ILogger {
+			public static class: java.lang.Class<io.sentry.DiagnosticLogger>;
+			public log(param0: io.sentry.SentryLevel, param1: string, param2: java.lang.Throwable): void;
+			public isEnabled(param0: io.sentry.SentryLevel): boolean;
+			public getLogger(): io.sentry.ILogger;
+			public log(param0: io.sentry.SentryLevel, param1: java.lang.Throwable, param2: string, param3: androidNative.Array<any>): void;
+			public constructor(param0: io.sentry.SentryOptions, param1: io.sentry.ILogger);
+			public log(param0: io.sentry.SentryLevel, param1: string, param2: androidNative.Array<any>): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export abstract class DirectoryProcessor {
+			public static class: java.lang.Class<io.sentry.DirectoryProcessor>;
+			public processDirectory(param0: java.io.File): void;
+			public processFile(param0: java.io.File, param1: any): void;
+			public isRelevantFileName(param0: string): boolean;
+		}
+		export module DirectoryProcessor {
+			export class SendCachedEnvelopeHint implements io.sentry.hints.Cached, io.sentry.hints.Retryable, io.sentry.hints.SubmissionResult, io.sentry.hints.Flushable {
+				public static class: java.lang.Class<io.sentry.DirectoryProcessor.SendCachedEnvelopeHint>;
+				public isRetry(): boolean;
+				public setResult(param0: boolean): void;
+				public constructor(param0: number, param1: io.sentry.ILogger);
+				public setRetry(param0: boolean): void;
+				public isSuccess(): boolean;
+				public waitFlush(): boolean;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class Dsn {
+			public static class: java.lang.Class<io.sentry.Dsn>;
+			public getSecretKey(): string;
+			public getPublicKey(): string;
+			public getPath(): string;
+			public getProjectId(): string;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class DuplicateEventDetectionEventProcessor extends io.sentry.EventProcessor {
+			public static class: java.lang.Class<io.sentry.DuplicateEventDetectionEventProcessor>;
+			public constructor(param0: io.sentry.SentryOptions);
+			public process(param0: io.sentry.SentryEvent, param1: any): io.sentry.SentryEvent;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class EnvelopeReader extends io.sentry.IEnvelopeReader {
+			public static class: java.lang.Class<io.sentry.EnvelopeReader>;
+			public read(param0: java.io.InputStream): io.sentry.SentryEnvelope;
+			public constructor();
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class EnvelopeSender extends io.sentry.DirectoryProcessor implements io.sentry.IEnvelopeSender {
+			public static class: java.lang.Class<io.sentry.EnvelopeSender>;
+			public processEnvelopeFile(param0: string, param1: any): void;
+			public constructor(param0: io.sentry.IHub, param1: io.sentry.ISerializer, param2: io.sentry.ILogger, param3: number);
+			public processFile(param0: java.io.File, param1: any): void;
+			public isRelevantFileName(param0: string): boolean;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class EventProcessor {
+			public static class: java.lang.Class<io.sentry.EventProcessor>;
+			/**
+			 * Constructs a new instance of the io.sentry.EventProcessor interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				process(param0: io.sentry.SentryEvent, param1: any): io.sentry.SentryEvent;
+			});
+			public constructor();
+			public process(param0: io.sentry.SentryEvent, param1: any): io.sentry.SentryEvent;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class GsonSerializer extends io.sentry.ISerializer {
+			public static class: java.lang.Class<io.sentry.GsonSerializer>;
+			public serialize(param0: io.sentry.SentryEnvelope, param1: java.io.OutputStream): void;
+			public serialize(param0: java.util.Map<string,any>): string;
+			public deserializeEnvelope(param0: java.io.InputStream): io.sentry.SentryEnvelope;
+			public constructor(param0: io.sentry.ILogger, param1: io.sentry.IEnvelopeReader);
+			public deserialize(param0: java.io.Reader, param1: java.lang.Class): any;
+			public serialize(param0: any, param1: java.io.Writer): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class HostnameCache {
+			public static class: java.lang.Class<io.sentry.HostnameCache>;
+			public constructor();
+		}
+		export module HostnameCache {
+			export class HostnameCacheThreadFactory {
+				public static class: java.lang.Class<io.sentry.HostnameCache.HostnameCacheThreadFactory>;
+				public newThread(param0: java.lang.Runnable): java.lang.Thread;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class Hub extends io.sentry.IHub {
+			public static class: java.lang.Class<io.sentry.Hub>;
+			public traceHeaders(): io.sentry.SentryTraceHeader;
+			public popScope(): void;
+			public clone(): io.sentry.IHub;
+			public captureMessage(param0: string, param1: io.sentry.SentryLevel): io.sentry.protocol.SentryId;
+			public captureTransaction(param0: io.sentry.ITransaction, param1: any): io.sentry.protocol.SentryId;
+			public captureException(param0: java.lang.Throwable): io.sentry.protocol.SentryId;
+			public captureEnvelope(param0: io.sentry.SentryEnvelope): io.sentry.protocol.SentryId;
+			public getSpan(): io.sentry.ISpan;
+			public addBreadcrumb(param0: string): void;
+			public getLastEventId(): io.sentry.protocol.SentryId;
+			public flush(param0: number): void;
+			public setExtra(param0: string, param1: string): void;
+			public getOptions(): io.sentry.SentryOptions;
+			public addBreadcrumb(param0: io.sentry.Breadcrumb, param1: any): void;
+			public constructor(param0: io.sentry.SentryOptions);
+			public captureEnvelope(param0: io.sentry.SentryEnvelope, param1: any): io.sentry.protocol.SentryId;
+			public setLevel(param0: io.sentry.SentryLevel): void;
+			public captureMessage(param0: string): io.sentry.protocol.SentryId;
+			public captureEvent(param0: io.sentry.SentryEvent): io.sentry.protocol.SentryId;
+			public startTransaction(param0: string, param1: string, param2: io.sentry.CustomSamplingContext): io.sentry.ITransaction;
+			public clearBreadcrumbs(): void;
+			public close(): void;
+			public captureTransaction(param0: io.sentry.ITransaction): io.sentry.protocol.SentryId;
+			public setTag(param0: string, param1: string): void;
+			public configureScope(param0: io.sentry.ScopeCallback): void;
+			public startSession(): void;
+			public addBreadcrumb(param0: string, param1: string): void;
+			public endSession(): void;
+			public removeExtra(param0: string): void;
+			public setTransaction(param0: string): void;
+			public setFingerprint(param0: java.util.List<string>): void;
+			public removeTag(param0: string): void;
+			public captureEvent(param0: io.sentry.SentryEvent, param1: any): io.sentry.protocol.SentryId;
+			public setSpanContext(param0: java.lang.Throwable, param1: io.sentry.ISpan): void;
+			public startTransaction(param0: io.sentry.TransactionContext, param1: io.sentry.CustomSamplingContext): io.sentry.ITransaction;
+			public captureException(param0: java.lang.Throwable, param1: any): io.sentry.protocol.SentryId;
+			public captureUserFeedback(param0: io.sentry.UserFeedback): void;
+			public setUser(param0: io.sentry.protocol.User): void;
+			public addBreadcrumb(param0: io.sentry.Breadcrumb): void;
+			public isEnabled(): boolean;
+			public startTransaction(param0: string, param1: string): io.sentry.ITransaction;
+			public withScope(param0: io.sentry.ScopeCallback): void;
+			public pushScope(): void;
+			public bindClient(param0: io.sentry.ISentryClient): void;
+			public startTransaction(param0: io.sentry.TransactionContext): io.sentry.ITransaction;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class HubAdapter extends io.sentry.IHub {
+			public static class: java.lang.Class<io.sentry.HubAdapter>;
+			public traceHeaders(): io.sentry.SentryTraceHeader;
+			public popScope(): void;
+			public clone(): io.sentry.IHub;
+			public captureMessage(param0: string, param1: io.sentry.SentryLevel): io.sentry.protocol.SentryId;
+			public captureTransaction(param0: io.sentry.ITransaction, param1: any): io.sentry.protocol.SentryId;
+			public captureException(param0: java.lang.Throwable): io.sentry.protocol.SentryId;
+			public captureEnvelope(param0: io.sentry.SentryEnvelope): io.sentry.protocol.SentryId;
+			public getSpan(): io.sentry.ISpan;
+			public addBreadcrumb(param0: string): void;
+			public getLastEventId(): io.sentry.protocol.SentryId;
+			public flush(param0: number): void;
+			public setExtra(param0: string, param1: string): void;
+			public getOptions(): io.sentry.SentryOptions;
+			public addBreadcrumb(param0: io.sentry.Breadcrumb, param1: any): void;
+			public captureEnvelope(param0: io.sentry.SentryEnvelope, param1: any): io.sentry.protocol.SentryId;
+			public setLevel(param0: io.sentry.SentryLevel): void;
+			public captureMessage(param0: string): io.sentry.protocol.SentryId;
+			public startTransaction(param0: string, param1: string, param2: io.sentry.CustomSamplingContext): io.sentry.ITransaction;
+			public captureEvent(param0: io.sentry.SentryEvent): io.sentry.protocol.SentryId;
+			public clearBreadcrumbs(): void;
+			public close(): void;
+			public captureTransaction(param0: io.sentry.ITransaction): io.sentry.protocol.SentryId;
+			public setTag(param0: string, param1: string): void;
+			public configureScope(param0: io.sentry.ScopeCallback): void;
+			public startSession(): void;
+			public addBreadcrumb(param0: string, param1: string): void;
+			public endSession(): void;
+			public removeExtra(param0: string): void;
+			public setTransaction(param0: string): void;
+			public setFingerprint(param0: java.util.List<string>): void;
+			public removeTag(param0: string): void;
+			public captureEvent(param0: io.sentry.SentryEvent, param1: any): io.sentry.protocol.SentryId;
+			public setSpanContext(param0: java.lang.Throwable, param1: io.sentry.ISpan): void;
+			public startTransaction(param0: io.sentry.TransactionContext, param1: io.sentry.CustomSamplingContext): io.sentry.ITransaction;
+			public captureException(param0: java.lang.Throwable, param1: any): io.sentry.protocol.SentryId;
+			public captureUserFeedback(param0: io.sentry.UserFeedback): void;
+			public setUser(param0: io.sentry.protocol.User): void;
+			public addBreadcrumb(param0: io.sentry.Breadcrumb): void;
+			public isEnabled(): boolean;
+			public startTransaction(param0: string, param1: string): io.sentry.ITransaction;
+			public static getInstance(): io.sentry.HubAdapter;
+			public withScope(param0: io.sentry.ScopeCallback): void;
+			public pushScope(): void;
+			public bindClient(param0: io.sentry.ISentryClient): void;
+			public startTransaction(param0: io.sentry.TransactionContext): io.sentry.ITransaction;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class IEnvelopeReader {
+			public static class: java.lang.Class<io.sentry.IEnvelopeReader>;
+			/**
+			 * Constructs a new instance of the io.sentry.IEnvelopeReader interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				read(param0: java.io.InputStream): io.sentry.SentryEnvelope;
+			});
+			public constructor();
+			public read(param0: java.io.InputStream): io.sentry.SentryEnvelope;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class IEnvelopeSender {
+			public static class: java.lang.Class<io.sentry.IEnvelopeSender>;
+			/**
+			 * Constructs a new instance of the io.sentry.IEnvelopeSender interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				processEnvelopeFile(param0: string, param1: any): void;
+			});
+			public constructor();
+			public processEnvelopeFile(param0: string, param1: any): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class IHub {
+			public static class: java.lang.Class<io.sentry.IHub>;
+			/**
+			 * Constructs a new instance of the io.sentry.IHub interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				isEnabled(): boolean;
+				captureEvent(param0: io.sentry.SentryEvent, param1: any): io.sentry.protocol.SentryId;
+				captureEvent(param0: io.sentry.SentryEvent): io.sentry.protocol.SentryId;
+				captureMessage(param0: string): io.sentry.protocol.SentryId;
+				captureMessage(param0: string, param1: io.sentry.SentryLevel): io.sentry.protocol.SentryId;
+				captureEnvelope(param0: io.sentry.SentryEnvelope, param1: any): io.sentry.protocol.SentryId;
+				captureEnvelope(param0: io.sentry.SentryEnvelope): io.sentry.protocol.SentryId;
+				captureException(param0: java.lang.Throwable, param1: any): io.sentry.protocol.SentryId;
+				captureException(param0: java.lang.Throwable): io.sentry.protocol.SentryId;
+				captureUserFeedback(param0: io.sentry.UserFeedback): void;
+				startSession(): void;
+				endSession(): void;
+				close(): void;
+				addBreadcrumb(param0: io.sentry.Breadcrumb, param1: any): void;
+				addBreadcrumb(param0: io.sentry.Breadcrumb): void;
+				addBreadcrumb(param0: string): void;
+				addBreadcrumb(param0: string, param1: string): void;
+				setLevel(param0: io.sentry.SentryLevel): void;
+				setTransaction(param0: string): void;
+				setUser(param0: io.sentry.protocol.User): void;
+				setFingerprint(param0: java.util.List<string>): void;
+				clearBreadcrumbs(): void;
+				setTag(param0: string, param1: string): void;
+				removeTag(param0: string): void;
+				setExtra(param0: string, param1: string): void;
+				removeExtra(param0: string): void;
+				getLastEventId(): io.sentry.protocol.SentryId;
+				pushScope(): void;
+				popScope(): void;
+				withScope(param0: io.sentry.ScopeCallback): void;
+				configureScope(param0: io.sentry.ScopeCallback): void;
+				bindClient(param0: io.sentry.ISentryClient): void;
+				flush(param0: number): void;
+				clone(): io.sentry.IHub;
+				captureTransaction(param0: io.sentry.ITransaction, param1: any): io.sentry.protocol.SentryId;
+				captureTransaction(param0: io.sentry.ITransaction): io.sentry.protocol.SentryId;
+				startTransaction(param0: io.sentry.TransactionContext): io.sentry.ITransaction;
+				startTransaction(param0: string, param1: string, param2: io.sentry.CustomSamplingContext): io.sentry.ITransaction;
+				startTransaction(param0: io.sentry.TransactionContext, param1: io.sentry.CustomSamplingContext): io.sentry.ITransaction;
+				startTransaction(param0: string, param1: string): io.sentry.ITransaction;
+				traceHeaders(): io.sentry.SentryTraceHeader;
+				setSpanContext(param0: java.lang.Throwable, param1: io.sentry.ISpan): void;
+				getSpan(): io.sentry.ISpan;
+				getOptions(): io.sentry.SentryOptions;
+			});
+			public constructor();
+			public traceHeaders(): io.sentry.SentryTraceHeader;
+			public popScope(): void;
+			public clone(): io.sentry.IHub;
+			public captureMessage(param0: string, param1: io.sentry.SentryLevel): io.sentry.protocol.SentryId;
+			public captureTransaction(param0: io.sentry.ITransaction, param1: any): io.sentry.protocol.SentryId;
+			public captureException(param0: java.lang.Throwable): io.sentry.protocol.SentryId;
+			public captureEnvelope(param0: io.sentry.SentryEnvelope): io.sentry.protocol.SentryId;
+			public addBreadcrumb(param0: string): void;
+			public getSpan(): io.sentry.ISpan;
+			public getLastEventId(): io.sentry.protocol.SentryId;
+			public flush(param0: number): void;
+			public setExtra(param0: string, param1: string): void;
+			public getOptions(): io.sentry.SentryOptions;
+			public addBreadcrumb(param0: io.sentry.Breadcrumb, param1: any): void;
+			public captureEnvelope(param0: io.sentry.SentryEnvelope, param1: any): io.sentry.protocol.SentryId;
+			public captureMessage(param0: string): io.sentry.protocol.SentryId;
+			public setLevel(param0: io.sentry.SentryLevel): void;
+			public captureEvent(param0: io.sentry.SentryEvent): io.sentry.protocol.SentryId;
+			public startTransaction(param0: string, param1: string, param2: io.sentry.CustomSamplingContext): io.sentry.ITransaction;
+			public clearBreadcrumbs(): void;
+			public close(): void;
+			public captureTransaction(param0: io.sentry.ITransaction): io.sentry.protocol.SentryId;
+			public setTag(param0: string, param1: string): void;
+			public configureScope(param0: io.sentry.ScopeCallback): void;
+			public startSession(): void;
+			public addBreadcrumb(param0: string, param1: string): void;
+			public endSession(): void;
+			public removeExtra(param0: string): void;
+			public setTransaction(param0: string): void;
+			public setFingerprint(param0: java.util.List<string>): void;
+			public removeTag(param0: string): void;
+			public captureEvent(param0: io.sentry.SentryEvent, param1: any): io.sentry.protocol.SentryId;
+			public setSpanContext(param0: java.lang.Throwable, param1: io.sentry.ISpan): void;
+			public startTransaction(param0: io.sentry.TransactionContext, param1: io.sentry.CustomSamplingContext): io.sentry.ITransaction;
+			public captureException(param0: java.lang.Throwable, param1: any): io.sentry.protocol.SentryId;
+			public captureUserFeedback(param0: io.sentry.UserFeedback): void;
+			public setUser(param0: io.sentry.protocol.User): void;
+			public addBreadcrumb(param0: io.sentry.Breadcrumb): void;
+			public isEnabled(): boolean;
+			public startTransaction(param0: string, param1: string): io.sentry.ITransaction;
+			public withScope(param0: io.sentry.ScopeCallback): void;
+			public pushScope(): void;
+			public bindClient(param0: io.sentry.ISentryClient): void;
+			public startTransaction(param0: io.sentry.TransactionContext): io.sentry.ITransaction;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class ILogger {
+			public static class: java.lang.Class<io.sentry.ILogger>;
+			/**
+			 * Constructs a new instance of the io.sentry.ILogger interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				log(param0: io.sentry.SentryLevel, param1: string, param2: androidNative.Array<any>): void;
+				log(param0: io.sentry.SentryLevel, param1: string, param2: java.lang.Throwable): void;
+				log(param0: io.sentry.SentryLevel, param1: java.lang.Throwable, param2: string, param3: androidNative.Array<any>): void;
+				isEnabled(param0: io.sentry.SentryLevel): boolean;
+			});
+			public constructor();
+			public log(param0: io.sentry.SentryLevel, param1: string, param2: java.lang.Throwable): void;
+			public isEnabled(param0: io.sentry.SentryLevel): boolean;
+			public log(param0: io.sentry.SentryLevel, param1: java.lang.Throwable, param2: string, param3: androidNative.Array<any>): void;
+			public log(param0: io.sentry.SentryLevel, param1: string, param2: androidNative.Array<any>): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class IScopeObserver {
+			public static class: java.lang.Class<io.sentry.IScopeObserver>;
+			/**
+			 * Constructs a new instance of the io.sentry.IScopeObserver interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				setUser(param0: io.sentry.protocol.User): void;
+				addBreadcrumb(param0: io.sentry.Breadcrumb): void;
+				setTag(param0: string, param1: string): void;
+				removeTag(param0: string): void;
+				setExtra(param0: string, param1: string): void;
+				removeExtra(param0: string): void;
+			});
+			public constructor();
+			public addBreadcrumb(param0: io.sentry.Breadcrumb): void;
+			public setExtra(param0: string, param1: string): void;
+			public removeExtra(param0: string): void;
+			public removeTag(param0: string): void;
+			public setUser(param0: io.sentry.protocol.User): void;
+			public setTag(param0: string, param1: string): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class ISentryClient {
+			public static class: java.lang.Class<io.sentry.ISentryClient>;
+			/**
+			 * Constructs a new instance of the io.sentry.ISentryClient interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				isEnabled(): boolean;
+				captureEvent(param0: io.sentry.SentryEvent, param1: io.sentry.Scope, param2: any): io.sentry.protocol.SentryId;
+				close(): void;
+				flush(param0: number): void;
+				captureEvent(param0: io.sentry.SentryEvent): io.sentry.protocol.SentryId;
+				captureEvent(param0: io.sentry.SentryEvent, param1: io.sentry.Scope): io.sentry.protocol.SentryId;
+				captureEvent(param0: io.sentry.SentryEvent, param1: any): io.sentry.protocol.SentryId;
+				captureMessage(param0: string, param1: io.sentry.SentryLevel, param2: io.sentry.Scope): io.sentry.protocol.SentryId;
+				captureMessage(param0: string, param1: io.sentry.SentryLevel): io.sentry.protocol.SentryId;
+				captureException(param0: java.lang.Throwable): io.sentry.protocol.SentryId;
+				captureException(param0: java.lang.Throwable, param1: io.sentry.Scope, param2: any): io.sentry.protocol.SentryId;
+				captureException(param0: java.lang.Throwable, param1: any): io.sentry.protocol.SentryId;
+				captureException(param0: java.lang.Throwable, param1: io.sentry.Scope): io.sentry.protocol.SentryId;
+				captureUserFeedback(param0: io.sentry.UserFeedback): void;
+				captureSession(param0: io.sentry.Session, param1: any): void;
+				captureSession(param0: io.sentry.Session): void;
+				captureEnvelope(param0: io.sentry.SentryEnvelope, param1: any): io.sentry.protocol.SentryId;
+				captureEnvelope(param0: io.sentry.SentryEnvelope): io.sentry.protocol.SentryId;
+				captureTransaction(param0: io.sentry.ITransaction, param1: io.sentry.Scope, param2: any): io.sentry.protocol.SentryId;
+				captureTransaction(param0: io.sentry.ITransaction): io.sentry.protocol.SentryId;
+			});
+			public constructor();
+			public captureSession(param0: io.sentry.Session): void;
+			public captureMessage(param0: string, param1: io.sentry.SentryLevel): io.sentry.protocol.SentryId;
+			public captureEvent(param0: io.sentry.SentryEvent, param1: any): io.sentry.protocol.SentryId;
+			public captureException(param0: java.lang.Throwable): io.sentry.protocol.SentryId;
+			public captureEnvelope(param0: io.sentry.SentryEnvelope): io.sentry.protocol.SentryId;
+			public flush(param0: number): void;
+			public captureMessage(param0: string, param1: io.sentry.SentryLevel, param2: io.sentry.Scope): io.sentry.protocol.SentryId;
+			public captureException(param0: java.lang.Throwable, param1: any): io.sentry.protocol.SentryId;
+			public captureTransaction(param0: io.sentry.ITransaction, param1: io.sentry.Scope, param2: any): io.sentry.protocol.SentryId;
+			public captureUserFeedback(param0: io.sentry.UserFeedback): void;
+			public captureException(param0: java.lang.Throwable, param1: io.sentry.Scope, param2: any): io.sentry.protocol.SentryId;
+			public captureSession(param0: io.sentry.Session, param1: any): void;
+			public isEnabled(): boolean;
+			public captureEnvelope(param0: io.sentry.SentryEnvelope, param1: any): io.sentry.protocol.SentryId;
+			public captureEvent(param0: io.sentry.SentryEvent): io.sentry.protocol.SentryId;
+			public captureEvent(param0: io.sentry.SentryEvent, param1: io.sentry.Scope): io.sentry.protocol.SentryId;
+			public close(): void;
+			public captureException(param0: java.lang.Throwable, param1: io.sentry.Scope): io.sentry.protocol.SentryId;
+			public captureEvent(param0: io.sentry.SentryEvent, param1: io.sentry.Scope, param2: any): io.sentry.protocol.SentryId;
+			public captureTransaction(param0: io.sentry.ITransaction): io.sentry.protocol.SentryId;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class ISentryExecutorService {
+			public static class: java.lang.Class<io.sentry.ISentryExecutorService>;
+			/**
+			 * Constructs a new instance of the io.sentry.ISentryExecutorService interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				submit(param0: java.lang.Runnable): java.util.concurrent.Future<any>;
+				close(param0: number): void;
+			});
+			public constructor();
+			public submit(param0: java.lang.Runnable): java.util.concurrent.Future<any>;
+			public close(param0: number): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class ISerializer {
+			public static class: java.lang.Class<io.sentry.ISerializer>;
+			/**
+			 * Constructs a new instance of the io.sentry.ISerializer interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				deserialize(param0: java.io.Reader, param1: java.lang.Class): any;
+				deserializeEnvelope(param0: java.io.InputStream): io.sentry.SentryEnvelope;
+				serialize(param0: any, param1: java.io.Writer): void;
+				serialize(param0: io.sentry.SentryEnvelope, param1: java.io.OutputStream): void;
+				serialize(param0: java.util.Map<string,any>): string;
+			});
+			public constructor();
+			public serialize(param0: io.sentry.SentryEnvelope, param1: java.io.OutputStream): void;
+			public serialize(param0: java.util.Map<string,any>): string;
+			public deserializeEnvelope(param0: java.io.InputStream): io.sentry.SentryEnvelope;
+			public deserialize(param0: java.io.Reader, param1: java.lang.Class): any;
+			public serialize(param0: any, param1: java.io.Writer): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class ISpan {
+			public static class: java.lang.Class<io.sentry.ISpan>;
+			/**
+			 * Constructs a new instance of the io.sentry.ISpan interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				startChild(param0: string): io.sentry.ISpan;
+				startChild(param0: string, param1: string): io.sentry.ISpan;
+				toSentryTrace(): io.sentry.SentryTraceHeader;
+				finish(): void;
+				finish(param0: io.sentry.SpanStatus): void;
+				setOperation(param0: string): void;
+				getOperation(): string;
+				setDescription(param0: string): void;
+				getDescription(): string;
+				setStatus(param0: io.sentry.SpanStatus): void;
+				getStatus(): io.sentry.SpanStatus;
+				setThrowable(param0: java.lang.Throwable): void;
+				getThrowable(): java.lang.Throwable;
+				getSpanContext(): io.sentry.SpanContext;
+				setTag(param0: string, param1: string): void;
+				isFinished(): boolean;
+			});
+			public constructor();
+			public setOperation(param0: string): void;
+			public startChild(param0: string, param1: string): io.sentry.ISpan;
+			public finish(): void;
+			public setDescription(param0: string): void;
+			public finish(param0: io.sentry.SpanStatus): void;
+			public getSpanContext(): io.sentry.SpanContext;
+			public setStatus(param0: io.sentry.SpanStatus): void;
+			public getThrowable(): java.lang.Throwable;
+			public isFinished(): boolean;
+			public getStatus(): io.sentry.SpanStatus;
+			public toSentryTrace(): io.sentry.SentryTraceHeader;
+			public getOperation(): string;
+			public getDescription(): string;
+			public startChild(param0: string): io.sentry.ISpan;
+			public setThrowable(param0: java.lang.Throwable): void;
+			public setTag(param0: string, param1: string): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class ITransaction extends io.sentry.ISpan {
+			public static class: java.lang.Class<io.sentry.ITransaction>;
+			/**
+			 * Constructs a new instance of the io.sentry.ITransaction interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				setName(param0: string): void;
+				getName(): string;
+				setRequest(param0: io.sentry.protocol.Request): void;
+				getRequest(): io.sentry.protocol.Request;
+				getContexts(): io.sentry.protocol.Contexts;
+				getSpans(): java.util.List<io.sentry.Span>;
+				isSampled(): java.lang.Boolean;
+				getLatestActiveSpan(): io.sentry.Span;
+				getEventId(): io.sentry.protocol.SentryId;
+				getTransaction(): string;
+				startChild(param0: string): io.sentry.ISpan;
+				startChild(param0: string, param1: string): io.sentry.ISpan;
+				toSentryTrace(): io.sentry.SentryTraceHeader;
+				finish(): void;
+				finish(param0: io.sentry.SpanStatus): void;
+				setOperation(param0: string): void;
+				getOperation(): string;
+				setDescription(param0: string): void;
+				getDescription(): string;
+				setStatus(param0: io.sentry.SpanStatus): void;
+				getStatus(): io.sentry.SpanStatus;
+				setThrowable(param0: java.lang.Throwable): void;
+				getThrowable(): java.lang.Throwable;
+				getSpanContext(): io.sentry.SpanContext;
+				setTag(param0: string, param1: string): void;
+				isFinished(): boolean;
+			});
+			public constructor();
+			public getEventId(): io.sentry.protocol.SentryId;
+			public finish(): void;
+			public getContexts(): io.sentry.protocol.Contexts;
+			public setStatus(param0: io.sentry.SpanStatus): void;
+			public isFinished(): boolean;
+			public getStatus(): io.sentry.SpanStatus;
+			public toSentryTrace(): io.sentry.SentryTraceHeader;
+			public getOperation(): string;
+			public setThrowable(param0: java.lang.Throwable): void;
+			public setTag(param0: string, param1: string): void;
+			public setRequest(param0: io.sentry.protocol.Request): void;
+			public setOperation(param0: string): void;
+			public startChild(param0: string, param1: string): io.sentry.ISpan;
+			public setDescription(param0: string): void;
+			public finish(param0: io.sentry.SpanStatus): void;
+			public getSpanContext(): io.sentry.SpanContext;
+			public getLatestActiveSpan(): io.sentry.Span;
+			public getRequest(): io.sentry.protocol.Request;
+			public getTransaction(): string;
+			public getThrowable(): java.lang.Throwable;
+			public getName(): string;
+			public getSpans(): java.util.List<io.sentry.Span>;
+			public isSampled(): java.lang.Boolean;
+			public getDescription(): string;
+			public startChild(param0: string): io.sentry.ISpan;
+			public setName(param0: string): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class ITransportFactory {
+			public static class: java.lang.Class<io.sentry.ITransportFactory>;
+			/**
+			 * Constructs a new instance of the io.sentry.ITransportFactory interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				create(param0: io.sentry.SentryOptions, param1: io.sentry.RequestDetails): io.sentry.transport.ITransport;
+			});
+			public constructor();
+			public create(param0: io.sentry.SentryOptions, param1: io.sentry.RequestDetails): io.sentry.transport.ITransport;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class IUnknownPropertiesConsumer {
+			public static class: java.lang.Class<io.sentry.IUnknownPropertiesConsumer>;
+			/**
+			 * Constructs a new instance of the io.sentry.IUnknownPropertiesConsumer interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+			});
+			public constructor();
+			public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class Integration {
+			public static class: java.lang.Class<io.sentry.Integration>;
+			/**
+			 * Constructs a new instance of the io.sentry.Integration interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				register(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): void;
+			});
+			public constructor();
+			public register(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class IpAddressUtils {
+			public static class: java.lang.Class<io.sentry.IpAddressUtils>;
+			public static isDefault(param0: string): boolean;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class MainEventProcessor extends io.sentry.EventProcessor {
+			public static class: java.lang.Class<io.sentry.MainEventProcessor>;
+			public static DEFAULT_IP_ADDRESS: string;
+			public process(param0: io.sentry.SentryEvent, param1: any): io.sentry.SentryEvent;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class NoOpEnvelopeReader extends io.sentry.IEnvelopeReader {
+			public static class: java.lang.Class<io.sentry.NoOpEnvelopeReader>;
+			public read(param0: java.io.InputStream): io.sentry.SentryEnvelope;
+			public static getInstance(): io.sentry.NoOpEnvelopeReader;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class NoOpHub extends io.sentry.IHub {
+			public static class: java.lang.Class<io.sentry.NoOpHub>;
+			public traceHeaders(): io.sentry.SentryTraceHeader;
+			public popScope(): void;
+			public clone(): io.sentry.IHub;
+			public captureMessage(param0: string, param1: io.sentry.SentryLevel): io.sentry.protocol.SentryId;
+			public static getInstance(): io.sentry.NoOpHub;
+			public captureTransaction(param0: io.sentry.ITransaction, param1: any): io.sentry.protocol.SentryId;
+			public captureException(param0: java.lang.Throwable): io.sentry.protocol.SentryId;
+			public captureEnvelope(param0: io.sentry.SentryEnvelope): io.sentry.protocol.SentryId;
+			public getSpan(): io.sentry.ISpan;
+			public addBreadcrumb(param0: string): void;
+			public getLastEventId(): io.sentry.protocol.SentryId;
+			public flush(param0: number): void;
+			public setExtra(param0: string, param1: string): void;
+			public getOptions(): io.sentry.SentryOptions;
+			public addBreadcrumb(param0: io.sentry.Breadcrumb, param1: any): void;
+			public captureEnvelope(param0: io.sentry.SentryEnvelope, param1: any): io.sentry.protocol.SentryId;
+			public setLevel(param0: io.sentry.SentryLevel): void;
+			public captureMessage(param0: string): io.sentry.protocol.SentryId;
+			public captureEvent(param0: io.sentry.SentryEvent): io.sentry.protocol.SentryId;
+			public startTransaction(param0: string, param1: string, param2: io.sentry.CustomSamplingContext): io.sentry.ITransaction;
+			public clearBreadcrumbs(): void;
+			public close(): void;
+			public captureTransaction(param0: io.sentry.ITransaction): io.sentry.protocol.SentryId;
+			public setTag(param0: string, param1: string): void;
+			public configureScope(param0: io.sentry.ScopeCallback): void;
+			public startSession(): void;
+			public addBreadcrumb(param0: string, param1: string): void;
+			public endSession(): void;
+			public removeExtra(param0: string): void;
+			public setTransaction(param0: string): void;
+			public setFingerprint(param0: java.util.List<string>): void;
+			public removeTag(param0: string): void;
+			public captureEvent(param0: io.sentry.SentryEvent, param1: any): io.sentry.protocol.SentryId;
+			public setSpanContext(param0: java.lang.Throwable, param1: io.sentry.ISpan): void;
+			public startTransaction(param0: io.sentry.TransactionContext, param1: io.sentry.CustomSamplingContext): io.sentry.ITransaction;
+			public captureException(param0: java.lang.Throwable, param1: any): io.sentry.protocol.SentryId;
+			public captureUserFeedback(param0: io.sentry.UserFeedback): void;
+			public setUser(param0: io.sentry.protocol.User): void;
+			public addBreadcrumb(param0: io.sentry.Breadcrumb): void;
+			public isEnabled(): boolean;
+			public startTransaction(param0: string, param1: string): io.sentry.ITransaction;
+			public withScope(param0: io.sentry.ScopeCallback): void;
+			public pushScope(): void;
+			public bindClient(param0: io.sentry.ISentryClient): void;
+			public startTransaction(param0: io.sentry.TransactionContext): io.sentry.ITransaction;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class NoOpLogger extends io.sentry.ILogger {
+			public static class: java.lang.Class<io.sentry.NoOpLogger>;
+			public static getInstance(): io.sentry.NoOpLogger;
+			public log(param0: io.sentry.SentryLevel, param1: string, param2: java.lang.Throwable): void;
+			public isEnabled(param0: io.sentry.SentryLevel): boolean;
+			public log(param0: io.sentry.SentryLevel, param1: java.lang.Throwable, param2: string, param3: androidNative.Array<any>): void;
+			public log(param0: io.sentry.SentryLevel, param1: string, param2: androidNative.Array<any>): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class NoOpSentryClient extends io.sentry.ISentryClient {
+			public static class: java.lang.Class<io.sentry.NoOpSentryClient>;
+			public captureSession(param0: io.sentry.Session): void;
+			public captureMessage(param0: string, param1: io.sentry.SentryLevel): io.sentry.protocol.SentryId;
+			public captureEvent(param0: io.sentry.SentryEvent, param1: any): io.sentry.protocol.SentryId;
+			public captureException(param0: java.lang.Throwable): io.sentry.protocol.SentryId;
+			public captureEnvelope(param0: io.sentry.SentryEnvelope): io.sentry.protocol.SentryId;
+			public flush(param0: number): void;
+			public captureTransaction(param0: io.sentry.ITransaction, param1: io.sentry.Scope, param2: any): io.sentry.protocol.SentryId;
+			public captureMessage(param0: string, param1: io.sentry.SentryLevel, param2: io.sentry.Scope): io.sentry.protocol.SentryId;
+			public captureException(param0: java.lang.Throwable, param1: any): io.sentry.protocol.SentryId;
+			public static getInstance(): io.sentry.NoOpSentryClient;
+			public captureUserFeedback(param0: io.sentry.UserFeedback): void;
+			public captureSession(param0: io.sentry.Session, param1: any): void;
+			public captureException(param0: java.lang.Throwable, param1: io.sentry.Scope, param2: any): io.sentry.protocol.SentryId;
+			public isEnabled(): boolean;
+			public captureEnvelope(param0: io.sentry.SentryEnvelope, param1: any): io.sentry.protocol.SentryId;
+			public captureEvent(param0: io.sentry.SentryEvent): io.sentry.protocol.SentryId;
+			public captureEvent(param0: io.sentry.SentryEvent, param1: io.sentry.Scope): io.sentry.protocol.SentryId;
+			public close(): void;
+			public captureException(param0: java.lang.Throwable, param1: io.sentry.Scope): io.sentry.protocol.SentryId;
+			public captureEvent(param0: io.sentry.SentryEvent, param1: io.sentry.Scope, param2: any): io.sentry.protocol.SentryId;
+			public captureTransaction(param0: io.sentry.ITransaction): io.sentry.protocol.SentryId;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class NoOpSerializer extends io.sentry.ISerializer {
+			public static class: java.lang.Class<io.sentry.NoOpSerializer>;
+			public serialize(param0: io.sentry.SentryEnvelope, param1: java.io.OutputStream): void;
+			public static getInstance(): io.sentry.NoOpSerializer;
+			public serialize(param0: java.util.Map<string,any>): string;
+			public deserializeEnvelope(param0: java.io.InputStream): io.sentry.SentryEnvelope;
+			public deserialize(param0: java.io.Reader, param1: java.lang.Class): any;
+			public serialize(param0: any, param1: java.io.Writer): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class NoOpSpan extends io.sentry.ISpan {
+			public static class: java.lang.Class<io.sentry.NoOpSpan>;
+			public setOperation(param0: string): void;
+			public startChild(param0: string, param1: string): io.sentry.ISpan;
+			public finish(): void;
+			public setDescription(param0: string): void;
+			public finish(param0: io.sentry.SpanStatus): void;
+			public getSpanContext(): io.sentry.SpanContext;
+			public setStatus(param0: io.sentry.SpanStatus): void;
+			public getThrowable(): java.lang.Throwable;
+			public isFinished(): boolean;
+			public getStatus(): io.sentry.SpanStatus;
+			public static getInstance(): io.sentry.NoOpSpan;
+			public toSentryTrace(): io.sentry.SentryTraceHeader;
+			public getOperation(): string;
+			public getDescription(): string;
+			public startChild(param0: string): io.sentry.ISpan;
+			public setThrowable(param0: java.lang.Throwable): void;
+			public setTag(param0: string, param1: string): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class NoOpTransaction extends io.sentry.ITransaction {
+			public static class: java.lang.Class<io.sentry.NoOpTransaction>;
+			public getEventId(): io.sentry.protocol.SentryId;
+			public finish(): void;
+			public getContexts(): io.sentry.protocol.Contexts;
+			public setStatus(param0: io.sentry.SpanStatus): void;
+			public isFinished(): boolean;
+			public getStatus(): io.sentry.SpanStatus;
+			public toSentryTrace(): io.sentry.SentryTraceHeader;
+			public getOperation(): string;
+			public setThrowable(param0: java.lang.Throwable): void;
+			public setTag(param0: string, param1: string): void;
+			public static getInstance(): io.sentry.NoOpTransaction;
+			public setRequest(param0: io.sentry.protocol.Request): void;
+			public setOperation(param0: string): void;
+			public startChild(param0: string, param1: string): io.sentry.ISpan;
+			public setDescription(param0: string): void;
+			public finish(param0: io.sentry.SpanStatus): void;
+			public getSpanContext(): io.sentry.SpanContext;
+			public getLatestActiveSpan(): io.sentry.Span;
+			public getRequest(): io.sentry.protocol.Request;
+			public getTransaction(): string;
+			public getThrowable(): java.lang.Throwable;
+			public getName(): string;
+			public getSpans(): java.util.List<io.sentry.Span>;
+			public isSampled(): java.lang.Boolean;
+			public getDescription(): string;
+			public startChild(param0: string): io.sentry.ISpan;
+			public setName(param0: string): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class NoOpTransportFactory extends io.sentry.ITransportFactory {
+			public static class: java.lang.Class<io.sentry.NoOpTransportFactory>;
+			public static getInstance(): io.sentry.NoOpTransportFactory;
+			public create(param0: io.sentry.SentryOptions, param1: io.sentry.RequestDetails): io.sentry.transport.ITransport;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class OptionsContainer<T>  extends java.lang.Object {
+			public static class: java.lang.Class<io.sentry.OptionsContainer<any>>;
+			public createInstance(): T;
+			public static create(param0: java.lang.Class): io.sentry.OptionsContainer<any>;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class OutboxSender extends io.sentry.DirectoryProcessor implements io.sentry.IEnvelopeSender {
+			public static class: java.lang.Class<io.sentry.OutboxSender>;
+			public processEnvelopeFile(param0: string, param1: any): void;
+			public constructor(param0: io.sentry.IHub, param1: io.sentry.IEnvelopeReader, param2: io.sentry.ISerializer, param3: io.sentry.ILogger, param4: number);
+			public processFile(param0: java.io.File, param1: any): void;
+			public isRelevantFileName(param0: string): boolean;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class RequestDetails {
+			public static class: java.lang.Class<io.sentry.RequestDetails>;
+			public getHeaders(): java.util.Map<string,string>;
+			public constructor(param0: string, param1: java.util.Map<string,string>);
+			public getUrl(): java.net.URL;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class RequestDetailsResolver {
+			public static class: java.lang.Class<io.sentry.RequestDetailsResolver>;
+			public constructor(param0: io.sentry.SentryOptions);
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SamplingContext {
+			public static class: java.lang.Class<io.sentry.SamplingContext>;
+			public constructor(param0: io.sentry.TransactionContext, param1: io.sentry.CustomSamplingContext);
+			public getCustomSamplingContext(): io.sentry.CustomSamplingContext;
+			public getTransactionContext(): io.sentry.TransactionContext;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class Scope {
+			public static class: java.lang.Class<io.sentry.Scope>;
+			public setContexts(param0: string, param1: string): void;
+			public clearTransaction(): void;
+			public getContexts(): io.sentry.protocol.Contexts;
+			public setContexts(param0: string, param1: java.lang.Boolean): void;
+			public getUser(): io.sentry.protocol.User;
+			public getSpan(): io.sentry.ISpan;
+			public removeContexts(param0: string): void;
+			public withTransaction(param0: io.sentry.Scope.IWithTransaction): void;
+			public setExtra(param0: string, param1: string): void;
+			public addBreadcrumb(param0: io.sentry.Breadcrumb, param1: any): void;
+			public constructor(param0: io.sentry.SentryOptions);
+			public setLevel(param0: io.sentry.SentryLevel): void;
+			public clearBreadcrumbs(): void;
+			public setTag(param0: string, param1: string): void;
+			public clear(): void;
+			public setRequest(param0: io.sentry.protocol.Request): void;
+			public getTransaction(): io.sentry.ITransaction;
+			public setTransaction(param0: io.sentry.ITransaction): void;
+			public removeExtra(param0: string): void;
+			public clone(): io.sentry.Scope;
+			public setTransaction(param0: string): void;
+			public setFingerprint(param0: java.util.List<string>): void;
+			public removeTag(param0: string): void;
+			public getTransactionName(): string;
+			public setUser(param0: io.sentry.protocol.User): void;
+			public getRequest(): io.sentry.protocol.Request;
+			public addBreadcrumb(param0: io.sentry.Breadcrumb): void;
+			public getLevel(): io.sentry.SentryLevel;
+			public addAttachment(param0: io.sentry.Attachment): void;
+			public setContexts(param0: string, param1: any): void;
+			public setContexts(param0: string, param1: java.lang.Number): void;
+			public addEventProcessor(param0: io.sentry.EventProcessor): void;
+		}
+		export module Scope {
+			export class IWithSession {
+				public static class: java.lang.Class<io.sentry.Scope.IWithSession>;
+				/**
+				 * Constructs a new instance of the io.sentry.Scope$IWithSession interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					accept(param0: io.sentry.Session): void;
+				});
+				public constructor();
+				public accept(param0: io.sentry.Session): void;
+			}
+			export class IWithTransaction {
+				public static class: java.lang.Class<io.sentry.Scope.IWithTransaction>;
+				/**
+				 * Constructs a new instance of the io.sentry.Scope$IWithTransaction interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					accept(param0: io.sentry.ITransaction): void;
+				});
+				public constructor();
+				public accept(param0: io.sentry.ITransaction): void;
+			}
+			export class SessionPair {
+				public static class: java.lang.Class<io.sentry.Scope.SessionPair>;
+				public getCurrent(): io.sentry.Session;
+				public constructor(param0: io.sentry.Session, param1: io.sentry.Session);
+				public getPrevious(): io.sentry.Session;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class ScopeCallback {
+			public static class: java.lang.Class<io.sentry.ScopeCallback>;
+			/**
+			 * Constructs a new instance of the io.sentry.ScopeCallback interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				run(param0: io.sentry.Scope): void;
+			});
+			public constructor();
+			public run(param0: io.sentry.Scope): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SendCachedEnvelopeFireAndForgetIntegration extends io.sentry.Integration {
+			public static class: java.lang.Class<io.sentry.SendCachedEnvelopeFireAndForgetIntegration>;
+			public register(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): void;
+			public constructor(param0: io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForgetFactory);
+		}
+		export module SendCachedEnvelopeFireAndForgetIntegration {
+			export class SendFireAndForget {
+				public static class: java.lang.Class<io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget>;
+				/**
+				 * Constructs a new instance of the io.sentry.SendCachedEnvelopeFireAndForgetIntegration$SendFireAndForget interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					send(): void;
+				});
+				public constructor();
+				public send(): void;
+			}
+			export class SendFireAndForgetDirPath {
+				public static class: java.lang.Class<io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForgetDirPath>;
+				/**
+				 * Constructs a new instance of the io.sentry.SendCachedEnvelopeFireAndForgetIntegration$SendFireAndForgetDirPath interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					getDirPath(): string;
+				});
+				public constructor();
+				public getDirPath(): string;
+			}
+			export class SendFireAndForgetFactory {
+				public static class: java.lang.Class<io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForgetFactory>;
+				/**
+				 * Constructs a new instance of the io.sentry.SendCachedEnvelopeFireAndForgetIntegration$SendFireAndForgetFactory interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					create(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget;
+					hasValidPath(param0: string, param1: io.sentry.ILogger): boolean;
+					processDir(param0: io.sentry.DirectoryProcessor, param1: string, param2: io.sentry.ILogger): io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget;
+					lambda$processDir$0(param0: io.sentry.ILogger, param1: string, param2: io.sentry.DirectoryProcessor, param3: java.io.File): void;
+				});
+				public constructor();
+				public hasValidPath(param0: string, param1: io.sentry.ILogger): boolean;
+				public create(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget;
+				public processDir(param0: io.sentry.DirectoryProcessor, param1: string, param2: io.sentry.ILogger): io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SendFireAndForgetEnvelopeSender extends io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForgetFactory {
+			public static class: java.lang.Class<io.sentry.SendFireAndForgetEnvelopeSender>;
+			public processDir(param0: io.sentry.DirectoryProcessor, param1: string, param2: io.sentry.ILogger): io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget;
+			public create(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget;
+			public constructor(param0: io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForgetDirPath);
+			public hasValidPath(param0: string, param1: io.sentry.ILogger): boolean;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SendFireAndForgetOutboxSender extends io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForgetFactory {
+			public static class: java.lang.Class<io.sentry.SendFireAndForgetOutboxSender>;
+			public processDir(param0: io.sentry.DirectoryProcessor, param1: string, param2: io.sentry.ILogger): io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget;
+			public create(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget;
+			public constructor(param0: io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForgetDirPath);
+			public hasValidPath(param0: string, param1: io.sentry.ILogger): boolean;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class Sentry {
+			public static class: java.lang.Class<io.sentry.Sentry>;
+			public static withScope(param0: io.sentry.ScopeCallback): void;
+			public static traceHeaders(): io.sentry.SentryTraceHeader;
+			public static init(param0: io.sentry.Sentry.OptionsConfiguration<io.sentry.SentryOptions>): void;
+			public static clearBreadcrumbs(): void;
+			public static setUser(param0: io.sentry.protocol.User): void;
+			public static captureException(param0: java.lang.Throwable, param1: any): io.sentry.protocol.SentryId;
+			public static popScope(): void;
+			public static addBreadcrumb(param0: string, param1: string): void;
+			public static startSession(): void;
+			public static captureMessage(param0: string, param1: io.sentry.SentryLevel): io.sentry.protocol.SentryId;
+			public static addBreadcrumb(param0: string): void;
+			public static setLevel(param0: io.sentry.SentryLevel): void;
+			public static addBreadcrumb(param0: io.sentry.Breadcrumb): void;
+			public static isEnabled(): boolean;
+			public static init(param0: io.sentry.OptionsContainer<any>, param1: io.sentry.Sentry.OptionsConfiguration<any>, param2: boolean): void;
+			public static captureUserFeedback(param0: io.sentry.UserFeedback): void;
+			public static startTransaction(param0: io.sentry.TransactionContext): io.sentry.ITransaction;
+			public static startTransaction(param0: io.sentry.TransactionContext, param1: io.sentry.CustomSamplingContext): io.sentry.ITransaction;
+			public static getSpan(): io.sentry.ISpan;
+			public static captureMessage(param0: string): io.sentry.protocol.SentryId;
+			public static addBreadcrumb(param0: io.sentry.Breadcrumb, param1: any): void;
+			public static captureEvent(param0: io.sentry.SentryEvent): io.sentry.protocol.SentryId;
+			public static captureEvent(param0: io.sentry.SentryEvent, param1: any): io.sentry.protocol.SentryId;
+			public static flush(param0: number): void;
+			public static captureException(param0: java.lang.Throwable): io.sentry.protocol.SentryId;
+			public static removeExtra(param0: string): void;
+			public static init(param0: io.sentry.SentryOptions): void;
+			public static startTransaction(param0: string, param1: string, param2: io.sentry.CustomSamplingContext): io.sentry.ITransaction;
+			public static init(param0: io.sentry.OptionsContainer<any>, param1: io.sentry.Sentry.OptionsConfiguration<any>): void;
+			public static setTransaction(param0: string): void;
+			public static setExtra(param0: string, param1: string): void;
+			public static startTransaction(param0: string, param1: string, param2: string): io.sentry.ITransaction;
+			public static init(): void;
+			public static getLastEventId(): io.sentry.protocol.SentryId;
+			public static setTag(param0: string, param1: string): void;
+			public static pushScope(): void;
+			public static configureScope(param0: io.sentry.ScopeCallback): void;
+			public static endSession(): void;
+			public static close(): void;
+			public static init(param0: io.sentry.Sentry.OptionsConfiguration<io.sentry.SentryOptions>, param1: boolean): void;
+			public static setFingerprint(param0: java.util.List<string>): void;
+			public static bindClient(param0: io.sentry.ISentryClient): void;
+			public static startTransaction(param0: string, param1: string): io.sentry.ITransaction;
+			public static init(param0: string): void;
+			public static removeTag(param0: string): void;
+		}
+		export module Sentry {
+			export class OptionsConfiguration<T>  extends java.lang.Object {
+				public static class: java.lang.Class<io.sentry.Sentry.OptionsConfiguration<any>>;
+				/**
+				 * Constructs a new instance of the io.sentry.Sentry$OptionsConfiguration interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					configure(param0: T): void;
+				});
+				public constructor();
+				public configure(param0: T): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export abstract class SentryBaseEvent {
+			public static class: java.lang.Class<io.sentry.SentryBaseEvent>;
+			public throwable: java.lang.Throwable;
+			public setTags(param0: java.util.Map<string,string>): void;
+			public getSdk(): io.sentry.protocol.SdkVersion;
+			public setRequest(param0: io.sentry.protocol.Request): void;
+			public getEventId(): io.sentry.protocol.SentryId;
+			public constructor(param0: io.sentry.protocol.SentryId);
+			public setEventId(param0: io.sentry.protocol.SentryId): void;
+			public getContexts(): io.sentry.protocol.Contexts;
+			public removeTag(param0: string): void;
+			public constructor();
+			public setSdk(param0: io.sentry.protocol.SdkVersion): void;
+			public getTag(param0: string): string;
+			public getRequest(): io.sentry.protocol.Request;
+			public getRelease(): string;
+			public getThrowable(): java.lang.Throwable;
+			public getOriginThrowable(): java.lang.Throwable;
+			public setEnvironment(param0: string): void;
+			public setRelease(param0: string): void;
+			public getEnvironment(): string;
+			public setThrowable(param0: java.lang.Throwable): void;
+			public setTag(param0: string, param1: string): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryClient extends io.sentry.ISentryClient {
+			public static class: java.lang.Class<io.sentry.SentryClient>;
+			public captureSession(param0: io.sentry.Session): void;
+			public captureMessage(param0: string, param1: io.sentry.SentryLevel): io.sentry.protocol.SentryId;
+			public captureEvent(param0: io.sentry.SentryEvent, param1: any): io.sentry.protocol.SentryId;
+			public captureException(param0: java.lang.Throwable): io.sentry.protocol.SentryId;
+			public captureEnvelope(param0: io.sentry.SentryEnvelope): io.sentry.protocol.SentryId;
+			public captureTransaction(param0: io.sentry.ITransaction, param1: io.sentry.Scope, param2: any): io.sentry.protocol.SentryId;
+			public flush(param0: number): void;
+			public captureMessage(param0: string, param1: io.sentry.SentryLevel, param2: io.sentry.Scope): io.sentry.protocol.SentryId;
+			public captureException(param0: java.lang.Throwable, param1: any): io.sentry.protocol.SentryId;
+			public captureUserFeedback(param0: io.sentry.UserFeedback): void;
+			public captureSession(param0: io.sentry.Session, param1: any): void;
+			public captureException(param0: java.lang.Throwable, param1: io.sentry.Scope, param2: any): io.sentry.protocol.SentryId;
+			public isEnabled(): boolean;
+			public captureEnvelope(param0: io.sentry.SentryEnvelope, param1: any): io.sentry.protocol.SentryId;
+			public captureEvent(param0: io.sentry.SentryEvent): io.sentry.protocol.SentryId;
+			public captureEvent(param0: io.sentry.SentryEvent, param1: io.sentry.Scope): io.sentry.protocol.SentryId;
+			public close(): void;
+			public captureException(param0: java.lang.Throwable, param1: io.sentry.Scope): io.sentry.protocol.SentryId;
+			public captureEvent(param0: io.sentry.SentryEvent, param1: io.sentry.Scope, param2: any): io.sentry.protocol.SentryId;
+			public captureTransaction(param0: io.sentry.ITransaction): io.sentry.protocol.SentryId;
+		}
+		export module SentryClient {
+			export class SortBreadcrumbsByDate extends java.util.Comparator<io.sentry.Breadcrumb> {
+				public static class: java.lang.Class<io.sentry.SentryClient.SortBreadcrumbsByDate>;
+				public compare(param0: io.sentry.Breadcrumb, param1: io.sentry.Breadcrumb): number;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryEnvelope {
+			public static class: java.lang.Class<io.sentry.SentryEnvelope>;
+			public constructor(param0: io.sentry.protocol.SentryId, param1: io.sentry.protocol.SdkVersion, param2: io.sentry.SentryEnvelopeItem);
+			public static from(param0: io.sentry.ISerializer, param1: io.sentry.SentryBaseEvent, param2: io.sentry.protocol.SdkVersion): io.sentry.SentryEnvelope;
+			public getHeader(): io.sentry.SentryEnvelopeHeader;
+			public constructor(param0: io.sentry.SentryEnvelopeHeader, param1: java.lang.Iterable<io.sentry.SentryEnvelopeItem>);
+			public constructor(param0: io.sentry.protocol.SentryId, param1: io.sentry.protocol.SdkVersion, param2: java.lang.Iterable<io.sentry.SentryEnvelopeItem>);
+			public getItems(): java.lang.Iterable<io.sentry.SentryEnvelopeItem>;
+			public static from(param0: io.sentry.ISerializer, param1: io.sentry.Session, param2: io.sentry.protocol.SdkVersion): io.sentry.SentryEnvelope;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryEnvelopeHeader {
+			public static class: java.lang.Class<io.sentry.SentryEnvelopeHeader>;
+			public getEventId(): io.sentry.protocol.SentryId;
+			public constructor(param0: io.sentry.protocol.SentryId);
+			public getSdkVersion(): io.sentry.protocol.SdkVersion;
+			public constructor(param0: io.sentry.protocol.SentryId, param1: io.sentry.protocol.SdkVersion);
+			public constructor();
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryEnvelopeHeaderAdapter extends com.google.gson.TypeAdapter<io.sentry.SentryEnvelopeHeader> {
+			public static class: java.lang.Class<io.sentry.SentryEnvelopeHeaderAdapter>;
+			public write(param0: com.google.gson.stream.JsonWriter, param1: io.sentry.SentryEnvelopeHeader): void;
+			public read(param0: com.google.gson.stream.JsonReader): io.sentry.SentryEnvelopeHeader;
+			public constructor();
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryEnvelopeItem {
+			public static class: java.lang.Class<io.sentry.SentryEnvelopeItem>;
+			public static fromAttachment(param0: io.sentry.Attachment, param1: number): io.sentry.SentryEnvelopeItem;
+			public static fromEvent(param0: io.sentry.ISerializer, param1: io.sentry.SentryBaseEvent): io.sentry.SentryEnvelopeItem;
+			public getTransaction(param0: io.sentry.ISerializer): io.sentry.ITransaction;
+			public getData(): androidNative.Array<number>;
+			public static fromSession(param0: io.sentry.ISerializer, param1: io.sentry.Session): io.sentry.SentryEnvelopeItem;
+			public static fromUserFeedback(param0: io.sentry.ISerializer, param1: io.sentry.UserFeedback): io.sentry.SentryEnvelopeItem;
+			public getEvent(param0: io.sentry.ISerializer): io.sentry.SentryEvent;
+			public getHeader(): io.sentry.SentryEnvelopeItemHeader;
+		}
+		export module SentryEnvelopeItem {
+			export class CachedItem {
+				public static class: java.lang.Class<io.sentry.SentryEnvelopeItem.CachedItem>;
+				public getBytes(): androidNative.Array<number>;
+				public constructor(param0: java.util.concurrent.Callable<androidNative.Array<number>>);
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryEnvelopeItemHeader {
+			public static class: java.lang.Class<io.sentry.SentryEnvelopeItemHeader>;
+			public getLength(): number;
+			public getFileName(): string;
+			public getType(): io.sentry.SentryItemType;
+			public getContentType(): string;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryEnvelopeItemHeaderAdapter extends com.google.gson.TypeAdapter<io.sentry.SentryEnvelopeItemHeader> {
+			public static class: java.lang.Class<io.sentry.SentryEnvelopeItemHeaderAdapter>;
+			public read(param0: com.google.gson.stream.JsonReader): io.sentry.SentryEnvelopeItemHeader;
+			public constructor();
+			public write(param0: com.google.gson.stream.JsonWriter, param1: io.sentry.SentryEnvelopeItemHeader): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryEvent extends io.sentry.SentryBaseEvent implements io.sentry.IUnknownPropertiesConsumer {
+			public static class: java.lang.Class<io.sentry.SentryEvent>;
+			public getThreads(): java.util.List<io.sentry.protocol.SentryThread>;
+			public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+			public constructor(param0: java.lang.Throwable);
+			public setServerName(param0: string): void;
+			public getPlatform(): string;
+			public getLogger(): string;
+			public getUser(): io.sentry.protocol.User;
+			public addBreadcrumb(param0: string): void;
+			public setDebugMeta(param0: io.sentry.protocol.DebugMeta): void;
+			public setPlatform(param0: string): void;
+			public setThreads(param0: java.util.List<io.sentry.protocol.SentryThread>): void;
+			public getTimestamp(): java.util.Date;
+			public setLevel(param0: io.sentry.SentryLevel): void;
+			public constructor(param0: java.util.Date);
+			public setExtra(param0: string, param1: any): void;
+			public setDist(param0: string): void;
+			public setMessage(param0: io.sentry.protocol.Message): void;
+			public getExtra(param0: string): any;
+			public setLogger(param0: string): void;
+			public getDebugMeta(): io.sentry.protocol.DebugMeta;
+			public setExceptions(param0: java.util.List<io.sentry.protocol.SentryException>): void;
+			public setExtras(param0: java.util.Map<string,any>): void;
+			public isErrored(): boolean;
+			public removeExtra(param0: string): void;
+			public constructor(param0: io.sentry.protocol.SentryId);
+			public setTransaction(param0: string): void;
+			public setFingerprints(param0: java.util.List<string>): void;
+			public constructor();
+			public isCrashed(): boolean;
+			public getDist(): string;
+			public setUser(param0: io.sentry.protocol.User): void;
+			public addBreadcrumb(param0: io.sentry.Breadcrumb): void;
+			public getExceptions(): java.util.List<io.sentry.protocol.SentryException>;
+			public getTransaction(): string;
+			public getUnknown(): java.util.Map<string,any>;
+			public setModule(param0: string, param1: string): void;
+			public setModules(param0: java.util.Map<string,string>): void;
+			public getLevel(): io.sentry.SentryLevel;
+			public getServerName(): string;
+			public setBreadcrumbs(param0: java.util.List<io.sentry.Breadcrumb>): void;
+			public getBreadcrumbs(): java.util.List<io.sentry.Breadcrumb>;
+			public getModule(param0: string): string;
+			public getFingerprints(): java.util.List<string>;
+			public removeModule(param0: string): void;
+			public getMessage(): io.sentry.protocol.Message;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryExceptionFactory {
+			public static class: java.lang.Class<io.sentry.SentryExceptionFactory>;
+			public constructor(param0: io.sentry.SentryStackTraceFactory);
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryExecutorService extends io.sentry.ISentryExecutorService {
+			public static class: java.lang.Class<io.sentry.SentryExecutorService>;
+			public submit(param0: java.lang.Runnable): java.util.concurrent.Future<any>;
+			public close(param0: number): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryItemType {
+			public static class: java.lang.Class<io.sentry.SentryItemType>;
+			public static Session: io.sentry.SentryItemType;
+			public static Event: io.sentry.SentryItemType;
+			public static UserFeedback: io.sentry.SentryItemType;
+			public static Attachment: io.sentry.SentryItemType;
+			public static Transaction: io.sentry.SentryItemType;
+			public static Unknown: io.sentry.SentryItemType;
+			public static resolve(param0: any): io.sentry.SentryItemType;
+			public static values(): androidNative.Array<io.sentry.SentryItemType>;
+			public getItemType(): string;
+			public static valueOf(param0: string): io.sentry.SentryItemType;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryLevel {
+			public static class: java.lang.Class<io.sentry.SentryLevel>;
+			public static DEBUG: io.sentry.SentryLevel;
+			public static INFO: io.sentry.SentryLevel;
+			public static WARNING: io.sentry.SentryLevel;
+			public static ERROR: io.sentry.SentryLevel;
+			public static FATAL: io.sentry.SentryLevel;
+			public static valueOf(param0: string): io.sentry.SentryLevel;
+			public static values(): androidNative.Array<io.sentry.SentryLevel>;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryOptions {
+			public static class: java.lang.Class<io.sentry.SentryOptions>;
+			public getBeforeBreadcrumb(): io.sentry.SentryOptions.BeforeBreadcrumbCallback;
+			public getMaxAttachmentSize(): number;
+			public isDebug(): boolean;
+			public setEnableExternalConfiguration(param0: boolean): void;
+			public getRelease(): string;
+			public setEnableScopeSync(param0: boolean): void;
+			public setEnableSessionTracking(param0: boolean): void;
+			public setMaxQueueSize(param0: number): void;
+			public setLogger(param0: io.sentry.ILogger): void;
+			public getMaxQueueSize(): number;
+			public setSerializer(param0: io.sentry.ISerializer): void;
+			public getConnectionTimeoutMillis(): number;
+			public getReadTimeoutMillis(): number;
+			public addIntegration(param0: io.sentry.Integration): void;
+			public getDistinctId(): string;
+			public getLogger(): io.sentry.ILogger;
+			public constructor();
+			public setDistinctId(param0: string): void;
+			public getDiagnosticLevel(): io.sentry.SentryLevel;
+			public getDist(): string;
+			public setHostnameVerifier(param0: javax.net.ssl.HostnameVerifier): void;
+			public getEventProcessors(): java.util.List<io.sentry.EventProcessor>;
+			public setDebug(param0: java.lang.Boolean): void;
+			public setEnvironment(param0: string): void;
+			public setTransportFactory(param0: io.sentry.ITransportFactory): void;
+			public getServerName(): string;
+			public getFlushTimeoutMillis(): number;
+			public isEnableUncaughtExceptionHandler(): boolean;
+			public setSendDefaultPii(param0: boolean): void;
+			public getShutdownTimeout(): number;
+			public setAttachServerName(param0: boolean): void;
+			public getProxy(): io.sentry.SentryOptions.Proxy;
+			public isSendDefaultPii(): boolean;
+			public setTransportGate(param0: io.sentry.transport.ITransportGate): void;
+			public setConnectionTimeoutMillis(param0: number): void;
+			public getTransportGate(): io.sentry.transport.ITransportGate;
+			public setAttachThreads(param0: boolean): void;
+			public getSdkVersion(): io.sentry.protocol.SdkVersion;
+			public setShutdownTimeout(param0: number): void;
+			public setDist(param0: string): void;
+			public getDsn(): string;
+			public setProxy(param0: io.sentry.SentryOptions.Proxy): void;
+			public getSampleRate(): java.lang.Double;
+			public getCacheDirSize(): number;
+			public setEnvelopeReader(param0: io.sentry.IEnvelopeReader): void;
+			public setSampleRate(param0: java.lang.Double): void;
+			public getIntegrations(): java.util.List<io.sentry.Integration>;
+			public setReadTimeoutMillis(param0: number): void;
+			public setMaxAttachmentSize(param0: number): void;
+			public setEnableNdk(param0: boolean): void;
+			public setTracesSampler(param0: io.sentry.SentryOptions.TracesSamplerCallback): void;
+			public setSdkVersion(param0: io.sentry.protocol.SdkVersion): void;
+			public setEnableDeduplication(param0: java.lang.Boolean): void;
+			public getTracesSampler(): io.sentry.SentryOptions.TracesSamplerCallback;
+			public setEnableUncaughtExceptionHandler(param0: java.lang.Boolean): void;
+			public setServerName(param0: string): void;
+			public setTracesSampleRate(param0: java.lang.Double): void;
+			public isEnableSessionTracking(): boolean;
+			public getInAppIncludes(): java.util.List<string>;
+			public getTransportFactory(): io.sentry.ITransportFactory;
+			public setSentryClientName(param0: string): void;
+			public isEnableExternalConfiguration(): boolean;
+			public addInAppInclude(param0: string): void;
+			public getEnvelopeDiskCache(): io.sentry.cache.IEnvelopeCache;
+			public getMaxBreadcrumbs(): number;
+			public isEnableNdk(): boolean;
+			public isEnableDeduplication(): boolean;
+			public setAttachStacktrace(param0: boolean): void;
+			public isEnableScopeSync(): boolean;
+			public getSerializer(): io.sentry.ISerializer;
+			public getOutboxPath(): string;
+			public setEnvelopeDiskCache(param0: io.sentry.cache.IEnvelopeCache): void;
+			public getEnvelopeReader(): io.sentry.IEnvelopeReader;
+			public setRelease(param0: string): void;
+			public setCacheDirSize(param0: number): void;
+			public getSentryClientName(): string;
+			public addScopeObserver(param0: io.sentry.IScopeObserver): void;
+			public getCacheDirPath(): string;
+			public setBeforeBreadcrumb(param0: io.sentry.SentryOptions.BeforeBreadcrumbCallback): void;
+			public setSslSocketFactory(param0: javax.net.ssl.SSLSocketFactory): void;
+			public addInAppExclude(param0: string): void;
+			public isAttachThreads(): boolean;
+			public setBeforeSend(param0: io.sentry.SentryOptions.BeforeSendCallback): void;
+			public setCacheDirPath(param0: string): void;
+			public getSessionTrackingIntervalMillis(): number;
+			public setFlushTimeoutMillis(param0: number): void;
+			public getTracesSampleRate(): java.lang.Double;
+			public getTags(): java.util.Map<string,string>;
+			public getInAppExcludes(): java.util.List<string>;
+			public setSessionTrackingIntervalMillis(param0: number): void;
+			public getEnableUncaughtExceptionHandler(): java.lang.Boolean;
+			public getHostnameVerifier(): javax.net.ssl.HostnameVerifier;
+			public getEnvironment(): string;
+			public setTag(param0: string, param1: string): void;
+			public getBeforeSend(): io.sentry.SentryOptions.BeforeSendCallback;
+			public setDsn(param0: string): void;
+			public isAttachServerName(): boolean;
+			public isAttachStacktrace(): boolean;
+			public getSslSocketFactory(): javax.net.ssl.SSLSocketFactory;
+			public setMaxBreadcrumbs(param0: number): void;
+			public setDiagnosticLevel(param0: io.sentry.SentryLevel): void;
+			public addEventProcessor(param0: io.sentry.EventProcessor): void;
+			public static from(param0: io.sentry.config.PropertiesProvider): io.sentry.SentryOptions;
+		}
+		export module SentryOptions {
+			export class BeforeBreadcrumbCallback {
+				public static class: java.lang.Class<io.sentry.SentryOptions.BeforeBreadcrumbCallback>;
+				/**
+				 * Constructs a new instance of the io.sentry.SentryOptions$BeforeBreadcrumbCallback interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					execute(param0: io.sentry.Breadcrumb, param1: any): io.sentry.Breadcrumb;
+				});
+				public constructor();
+				public execute(param0: io.sentry.Breadcrumb, param1: any): io.sentry.Breadcrumb;
+			}
+			export class BeforeSendCallback {
+				public static class: java.lang.Class<io.sentry.SentryOptions.BeforeSendCallback>;
+				/**
+				 * Constructs a new instance of the io.sentry.SentryOptions$BeforeSendCallback interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					execute(param0: io.sentry.SentryEvent, param1: any): io.sentry.SentryEvent;
+				});
+				public constructor();
+				public execute(param0: io.sentry.SentryEvent, param1: any): io.sentry.SentryEvent;
+			}
+			export class Proxy {
+				public static class: java.lang.Class<io.sentry.SentryOptions.Proxy>;
+				public getPort(): string;
+				public getPass(): string;
+				public getUser(): string;
+				public setPass(param0: string): void;
+				public setUser(param0: string): void;
+				public constructor(param0: string, param1: string, param2: string, param3: string);
+				public getHost(): string;
+				public setHost(param0: string): void;
+				public setPort(param0: string): void;
+				public constructor(param0: string, param1: string);
+				public constructor();
+			}
+			export class TracesSamplerCallback {
+				public static class: java.lang.Class<io.sentry.SentryOptions.TracesSamplerCallback>;
+				/**
+				 * Constructs a new instance of the io.sentry.SentryOptions$TracesSamplerCallback interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					sample(param0: io.sentry.SamplingContext): java.lang.Double;
+				});
+				public constructor();
+				public sample(param0: io.sentry.SamplingContext): java.lang.Double;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryStackTraceFactory {
+			public static class: java.lang.Class<io.sentry.SentryStackTraceFactory>;
+			public constructor(param0: java.util.List<string>, param1: java.util.List<string>);
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryThreadFactory {
+			public static class: java.lang.Class<io.sentry.SentryThreadFactory>;
+			public constructor(param0: io.sentry.SentryStackTraceFactory, param1: io.sentry.SentryOptions);
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryTraceHeader {
+			public static class: java.lang.Class<io.sentry.SentryTraceHeader>;
+			public static SENTRY_TRACE_HEADER: string;
+			public getName(): string;
+			public isSampled(): java.lang.Boolean;
+			public constructor(param0: io.sentry.protocol.SentryId, param1: io.sentry.SpanId, param2: java.lang.Boolean);
+			public getValue(): string;
+			public getTraceId(): io.sentry.protocol.SentryId;
+			public constructor(param0: string);
+			public getSpanId(): io.sentry.SpanId;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryTransaction extends io.sentry.SentryBaseEvent implements io.sentry.ITransaction {
+			public static class: java.lang.Class<io.sentry.SentryTransaction>;
+			public constructor(param0: string, param1: string, param2: io.sentry.IHub);
+			public getEventId(): io.sentry.protocol.SentryId;
+			public finish(): void;
+			public getContexts(): io.sentry.protocol.Contexts;
+			public setStatus(param0: io.sentry.SpanStatus): void;
+			public isFinished(): boolean;
+			public getStatus(): io.sentry.SpanStatus;
+			public toSentryTrace(): io.sentry.SentryTraceHeader;
+			public getOperation(): string;
+			public setThrowable(param0: java.lang.Throwable): void;
+			public setTag(param0: string, param1: string): void;
+			public setRequest(param0: io.sentry.protocol.Request): void;
+			public setOperation(param0: string): void;
+			public constructor(param0: io.sentry.protocol.SentryId);
+			public startChild(param0: string, param1: string): io.sentry.ISpan;
+			public setDescription(param0: string): void;
+			public finish(param0: io.sentry.SpanStatus): void;
+			public constructor();
+			public getSpanContext(): io.sentry.SpanContext;
+			public getLatestActiveSpan(): io.sentry.Span;
+			public getRequest(): io.sentry.protocol.Request;
+			public getTransaction(): string;
+			public getThrowable(): java.lang.Throwable;
+			public getName(): string;
+			public getSpans(): java.util.List<io.sentry.Span>;
+			public isSampled(): java.lang.Boolean;
+			public getDescription(): string;
+			public startChild(param0: string): io.sentry.ISpan;
+			public constructor(param0: string, param1: io.sentry.SpanContext, param2: io.sentry.IHub);
+			public setName(param0: string): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SentryValues<T>  extends java.lang.Object {
+			public static class: java.lang.Class<io.sentry.SentryValues<any>>;
+			public getValues(): java.util.List<T>;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class Session {
+			public static class: java.lang.Class<io.sentry.Session>;
+			public end(param0: java.util.Date): void;
+			public constructor(param0: io.sentry.Session.State, param1: java.util.Date, param2: java.util.Date, param3: number, param4: string, param5: java.util.UUID, param6: java.lang.Boolean, param7: java.lang.Long, param8: java.lang.Double, param9: string, param10: string, param11: string, param12: string);
+			public setInitAsTrue(): void;
+			public getDistinctId(): string;
+			public end(): void;
+			public getUserAgent(): string;
+			public getStarted(): java.util.Date;
+			public getSessionId(): java.util.UUID;
+			public errorCount(): number;
+			public update(param0: io.sentry.Session.State, param1: string, param2: boolean): boolean;
+			public getIpAddress(): string;
+			public getDuration(): java.lang.Double;
+			public getInit(): java.lang.Boolean;
+			public getRelease(): string;
+			public constructor(param0: string, param1: io.sentry.protocol.User, param2: string, param3: string);
+			public getSequence(): java.lang.Long;
+			public getStatus(): io.sentry.Session.State;
+			public getTimestamp(): java.util.Date;
+			public clone(): io.sentry.Session;
+			public getEnvironment(): string;
+		}
+		export module Session {
+			export class State {
+				public static class: java.lang.Class<io.sentry.Session.State>;
+				public static Ok: io.sentry.Session.State;
+				public static Exited: io.sentry.Session.State;
+				public static Crashed: io.sentry.Session.State;
+				public static Abnormal: io.sentry.Session.State;
+				public static valueOf(param0: string): io.sentry.Session.State;
+				public static values(): androidNative.Array<io.sentry.Session.State>;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SessionAdapter extends com.google.gson.TypeAdapter<io.sentry.Session> {
+			public static class: java.lang.Class<io.sentry.SessionAdapter>;
+			public read(param0: com.google.gson.stream.JsonReader): io.sentry.Session;
+			public write(param0: com.google.gson.stream.JsonWriter, param1: io.sentry.Session): void;
+			public constructor(param0: io.sentry.ILogger);
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class ShutdownHookIntegration extends io.sentry.Integration {
+			public static class: java.lang.Class<io.sentry.ShutdownHookIntegration>;
+			public register(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): void;
+			public constructor();
+			public constructor(param0: java.lang.Runtime);
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class Span extends io.sentry.SpanContext implements io.sentry.ISpan {
+			public static class: java.lang.Class<io.sentry.Span>;
+			public setOperation(param0: string): void;
+			public startChild(param0: string, param1: string): io.sentry.ISpan;
+			public finish(): void;
+			public setDescription(param0: string): void;
+			public finish(param0: io.sentry.SpanStatus): void;
+			public getSpanContext(): io.sentry.SpanContext;
+			public setStatus(param0: io.sentry.SpanStatus): void;
+			public getThrowable(): java.lang.Throwable;
+			public isFinished(): boolean;
+			public getTimestamp(): java.util.Date;
+			public getStatus(): io.sentry.SpanStatus;
+			public toSentryTrace(): io.sentry.SentryTraceHeader;
+			public getOperation(): string;
+			public getDescription(): string;
+			public getStartTimestamp(): java.util.Date;
+			public startChild(param0: string): io.sentry.ISpan;
+			public setThrowable(param0: java.lang.Throwable): void;
+			public setTag(param0: string, param1: string): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SpanContext {
+			public static class: java.lang.Class<io.sentry.SpanContext>;
+			public static TYPE: string;
+			public op: string;
+			public description: string;
+			public status: io.sentry.SpanStatus;
+			public tags: java.util.Map<string,string>;
+			public constructor(param0: io.sentry.protocol.SentryId, param1: io.sentry.SpanId, param2: string, param3: io.sentry.SpanId, param4: java.lang.Boolean);
+			public setOperation(param0: string): void;
+			public getSampled(): java.lang.Boolean;
+			public setDescription(param0: string): void;
+			public constructor(param0: string, param1: java.lang.Boolean);
+			public getTraceId(): io.sentry.protocol.SentryId;
+			public getSpanId(): io.sentry.SpanId;
+			public setStatus(param0: io.sentry.SpanStatus): void;
+			public getParentSpanId(): io.sentry.SpanId;
+			public getTags(): java.util.Map<string,string>;
+			public getStatus(): io.sentry.SpanStatus;
+			public getOperation(): string;
+			public getDescription(): string;
+			public clone(): io.sentry.SpanContext;
+			public constructor(param0: string);
+			public setTag(param0: string, param1: string): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SpanId {
+			public static class: java.lang.Class<io.sentry.SpanId>;
+			public static EMPTY_ID: io.sentry.SpanId;
+			public equals(param0: any): boolean;
+			public toString(): string;
+			public constructor();
+			public constructor(param0: string);
+			public hashCode(): number;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SpanStatus {
+			public static class: java.lang.Class<io.sentry.SpanStatus>;
+			public static OK: io.sentry.SpanStatus;
+			public static CANCELLED: io.sentry.SpanStatus;
+			public static INTERNAL_ERROR: io.sentry.SpanStatus;
+			public static UNKNOWN: io.sentry.SpanStatus;
+			public static UNKNOWN_ERROR: io.sentry.SpanStatus;
+			public static INVALID_ARGUMENT: io.sentry.SpanStatus;
+			public static DEADLINE_EXCEEDED: io.sentry.SpanStatus;
+			public static NOT_FOUND: io.sentry.SpanStatus;
+			public static ALREADY_EXISTS: io.sentry.SpanStatus;
+			public static PERMISSION_DENIED: io.sentry.SpanStatus;
+			public static RESOURCE_EXHAUSTED: io.sentry.SpanStatus;
+			public static FAILED_PRECONDITION: io.sentry.SpanStatus;
+			public static ABORTED: io.sentry.SpanStatus;
+			public static OUT_OF_RANGE: io.sentry.SpanStatus;
+			public static UNIMPLEMENTED: io.sentry.SpanStatus;
+			public static UNAVAILABLE: io.sentry.SpanStatus;
+			public static DATA_LOSS: io.sentry.SpanStatus;
+			public static UNAUTHENTICATED: io.sentry.SpanStatus;
+			public static valueOf(param0: string): io.sentry.SpanStatus;
+			public static fromHttpStatusCode(param0: number): io.sentry.SpanStatus;
+			public static fromHttpStatusCode(param0: number, param1: io.sentry.SpanStatus): io.sentry.SpanStatus;
+			public static values(): androidNative.Array<io.sentry.SpanStatus>;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class Stack {
+			public static class: java.lang.Class<io.sentry.Stack>;
+			public constructor(param0: io.sentry.ILogger, param1: io.sentry.Stack.StackItem);
+			public constructor(param0: io.sentry.Stack);
+		}
+		export module Stack {
+			export class StackItem {
+				public static class: java.lang.Class<io.sentry.Stack.StackItem>;
+				public getOptions(): io.sentry.SentryOptions;
+				public getClient(): io.sentry.ISentryClient;
+				public getScope(): io.sentry.Scope;
+				public setClient(param0: io.sentry.ISentryClient): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SynchronizedCollection<E>  extends java.lang.Object {
+			public static class: java.lang.Class<io.sentry.SynchronizedCollection<any>>;
+			public clear(): void;
+			public equals(param0: any): boolean;
+			public isEmpty(): boolean;
+			public iterator(): java.util.Iterator<E>;
+			public size(): number;
+			public decorated(): java.util.Collection<E>;
+			public add(param0: E): boolean;
+			public static synchronizedCollection(param0: java.util.Collection): io.sentry.SynchronizedCollection<any>;
+			public addAll(param0: java.util.Collection<any>): boolean;
+			public retainAll(param0: java.util.Collection<any>): boolean;
+			public remove(param0: any): boolean;
+			public containsAll(param0: java.util.Collection<any>): boolean;
+			public toArray(): androidNative.Array<any>;
+			public contains(param0: any): boolean;
+			public toString(): string;
+			public removeAll(param0: java.util.Collection<any>): boolean;
+			public toArray(param0: androidNative.Array<any>): androidNative.Array<any>;
+			public hashCode(): number;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SynchronizedQueue<E>  extends io.sentry.SynchronizedCollection<any> implements java.util.Queue<any>  {
+			public static class: java.lang.Class<io.sentry.SynchronizedQueue<any>>;
+			public peek(): any;
+			public remove(param0: any): boolean;
+			public constructor(param0: java.util.Queue<any>, param1: any);
+			public equals(param0: any): boolean;
+			public decorated(): java.util.Queue<any>;
+			public offer(param0: any): boolean;
+			public remove(): any;
+			public poll(): any;
+			public decorated(): java.util.Collection<any>;
+			public element(): any;
+			public hashCode(): number;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class SystemOutLogger extends io.sentry.ILogger {
+			public static class: java.lang.Class<io.sentry.SystemOutLogger>;
+			public log(param0: io.sentry.SentryLevel, param1: string, param2: java.lang.Throwable): void;
+			public isEnabled(param0: io.sentry.SentryLevel): boolean;
+			public log(param0: io.sentry.SentryLevel, param1: java.lang.Throwable, param2: string, param3: androidNative.Array<any>): void;
+			public constructor();
+			public log(param0: io.sentry.SentryLevel, param1: string, param2: androidNative.Array<any>): void;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class TracesSampler {
+			public static class: java.lang.Class<io.sentry.TracesSampler>;
+			public constructor(param0: io.sentry.SentryOptions);
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class TransactionContext extends io.sentry.SpanContext {
+			public static class: java.lang.Class<io.sentry.TransactionContext>;
+			public static fromSentryTrace(param0: string, param1: string, param2: io.sentry.SentryTraceHeader): io.sentry.TransactionContext;
+			public constructor(param0: string, param1: string);
+			public constructor(param0: io.sentry.protocol.SentryId, param1: io.sentry.SpanId, param2: string, param3: io.sentry.SpanId, param4: java.lang.Boolean);
+			public getName(): string;
+			public constructor(param0: string, param1: string, param2: java.lang.Boolean);
+			public constructor(param0: string, param1: java.lang.Boolean);
+			public setParentSampled(param0: java.lang.Boolean): void;
+			public getParentSampled(): java.lang.Boolean;
+			public constructor(param0: string);
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class UncaughtExceptionHandler {
+			public static class: java.lang.Class<io.sentry.UncaughtExceptionHandler>;
+			/**
+			 * Constructs a new instance of the io.sentry.UncaughtExceptionHandler interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+			 */
+			public constructor(implementation: {
+				getDefaultUncaughtExceptionHandler(): java.lang.Thread.UncaughtExceptionHandler;
+				setDefaultUncaughtExceptionHandler(param0: java.lang.Thread.UncaughtExceptionHandler): void;
+			});
+			public constructor();
+			public getDefaultUncaughtExceptionHandler(): java.lang.Thread.UncaughtExceptionHandler;
+			public setDefaultUncaughtExceptionHandler(param0: java.lang.Thread.UncaughtExceptionHandler): void;
+		}
+		export module UncaughtExceptionHandler {
+			export class Adapter extends io.sentry.UncaughtExceptionHandler {
+				public static class: java.lang.Class<io.sentry.UncaughtExceptionHandler.Adapter>;
+				public setDefaultUncaughtExceptionHandler(param0: java.lang.Thread.UncaughtExceptionHandler): void;
+				public getDefaultUncaughtExceptionHandler(): java.lang.Thread.UncaughtExceptionHandler;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class UncaughtExceptionHandlerIntegration extends io.sentry.Integration {
+			public static class: java.lang.Class<io.sentry.UncaughtExceptionHandlerIntegration>;
+			public register(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): void;
+			public constructor();
+			public uncaughtException(param0: java.lang.Thread, param1: java.lang.Throwable): void;
+			public close(): void;
+		}
+		export module UncaughtExceptionHandlerIntegration {
+			export class UncaughtExceptionHint implements io.sentry.hints.DiskFlushNotification, io.sentry.hints.Flushable, io.sentry.hints.SessionEnd {
+				public static class: java.lang.Class<io.sentry.UncaughtExceptionHandlerIntegration.UncaughtExceptionHint>;
+				public markFlushed(): void;
+				public waitFlush(): boolean;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class UnknownPropertiesTypeAdapterFactory {
+			public static class: java.lang.Class<io.sentry.UnknownPropertiesTypeAdapterFactory>;
+			public create(param0: com.google.gson.Gson, param1: com.google.gson.reflect.TypeToken): com.google.gson.TypeAdapter;
+		}
+		export module UnknownPropertiesTypeAdapterFactory {
+			export class UnknownPropertiesTypeAdapter<T>  extends com.google.gson.TypeAdapter<any> {
+				public static class: java.lang.Class<io.sentry.UnknownPropertiesTypeAdapterFactory.UnknownPropertiesTypeAdapter<any>>;
+				public read(param0: com.google.gson.stream.JsonReader): any;
+				public write(param0: com.google.gson.stream.JsonWriter, param1: any): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export class UserFeedback {
+			public static class: java.lang.Class<io.sentry.UserFeedback>;
+			public setEmail(param0: string): void;
+			public toString(): string;
+			public getEventId(): io.sentry.protocol.SentryId;
+			public getName(): string;
+			public constructor(param0: io.sentry.protocol.SentryId);
+			public getComments(): string;
+			public setComments(param0: string): void;
+			public constructor(param0: io.sentry.protocol.SentryId, param1: string, param2: string, param3: string);
+			public setName(param0: string): void;
+			public getEmail(): string;
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class CollectionAdapter extends com.google.gson.JsonSerializer<java.util.Collection<any>> {
+				public static class: java.lang.Class<io.sentry.adapters.CollectionAdapter>;
+				public serialize(param0: java.util.Collection<any>, param1: java.lang.reflect.Type, param2: com.google.gson.JsonSerializationContext): com.google.gson.JsonElement;
 				public constructor();
 			}
 		}
 	}
 }
 
-declare module com {
-	export module google {
-		export module gson {
-			export class DefaultDateTypeAdapter extends com.google.gson.TypeAdapter<java.util.Date> {
-				public static class: java.lang.Class<com.google.gson.DefaultDateTypeAdapter>;
-				public constructor(param0: number, param1: number);
-				public read(param0: any): any;
-				public read(param0: any): java.util.Date;
-				public write(param0: any, param1: java.util.Date): void;
-				public write(param0: any, param1: any): void;
-				public constructor(param0: java.lang.Class<any>, param1: number, param2: number);
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class ContextsDeserializerAdapter extends com.google.gson.JsonDeserializer<io.sentry.protocol.Contexts> {
+				public static class: java.lang.Class<io.sentry.adapters.ContextsDeserializerAdapter>;
+				public constructor(param0: io.sentry.ILogger);
+				public deserialize(param0: com.google.gson.JsonElement, param1: java.lang.reflect.Type, param2: com.google.gson.JsonDeserializationContext): io.sentry.protocol.Contexts;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class ContextsSerializerAdapter extends com.google.gson.JsonSerializer<io.sentry.protocol.Contexts> {
+				public static class: java.lang.Class<io.sentry.adapters.ContextsSerializerAdapter>;
+				public serialize(param0: io.sentry.protocol.Contexts, param1: java.lang.reflect.Type, param2: com.google.gson.JsonSerializationContext): com.google.gson.JsonElement;
+				public constructor(param0: io.sentry.ILogger);
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class DateDeserializerAdapter extends com.google.gson.JsonDeserializer<java.util.Date> {
+				public static class: java.lang.Class<io.sentry.adapters.DateDeserializerAdapter>;
+				public deserialize(param0: com.google.gson.JsonElement, param1: java.lang.reflect.Type, param2: com.google.gson.JsonDeserializationContext): java.util.Date;
+				public constructor(param0: io.sentry.ILogger);
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class DateSerializerAdapter extends com.google.gson.JsonSerializer<java.util.Date> {
+				public static class: java.lang.Class<io.sentry.adapters.DateSerializerAdapter>;
+				public constructor(param0: io.sentry.ILogger);
+				public serialize(param0: java.util.Date, param1: java.lang.reflect.Type, param2: com.google.gson.JsonSerializationContext): com.google.gson.JsonElement;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class MapAdapter extends com.google.gson.JsonSerializer<java.util.Map<string,any>> {
+				public static class: java.lang.Class<io.sentry.adapters.MapAdapter>;
+				public serialize(param0: java.util.Map<string,any>, param1: java.lang.reflect.Type, param2: com.google.gson.JsonSerializationContext): com.google.gson.JsonElement;
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class OrientationDeserializerAdapter extends com.google.gson.JsonDeserializer<io.sentry.protocol.Device.DeviceOrientation> {
+				public static class: java.lang.Class<io.sentry.adapters.OrientationDeserializerAdapter>;
+				public deserialize(param0: com.google.gson.JsonElement, param1: java.lang.reflect.Type, param2: com.google.gson.JsonDeserializationContext): io.sentry.protocol.Device.DeviceOrientation;
+				public constructor(param0: io.sentry.ILogger);
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class OrientationSerializerAdapter extends com.google.gson.JsonSerializer<io.sentry.protocol.Device.DeviceOrientation> {
+				public static class: java.lang.Class<io.sentry.adapters.OrientationSerializerAdapter>;
+				public constructor(param0: io.sentry.ILogger);
+				public serialize(param0: io.sentry.protocol.Device.DeviceOrientation, param1: java.lang.reflect.Type, param2: com.google.gson.JsonSerializationContext): com.google.gson.JsonElement;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class SentryIdDeserializerAdapter extends com.google.gson.JsonDeserializer<io.sentry.protocol.SentryId> {
+				public static class: java.lang.Class<io.sentry.adapters.SentryIdDeserializerAdapter>;
+				public constructor(param0: io.sentry.ILogger);
+				public deserialize(param0: com.google.gson.JsonElement, param1: java.lang.reflect.Type, param2: com.google.gson.JsonDeserializationContext): io.sentry.protocol.SentryId;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class SentryIdSerializerAdapter extends com.google.gson.JsonSerializer<io.sentry.protocol.SentryId> {
+				public static class: java.lang.Class<io.sentry.adapters.SentryIdSerializerAdapter>;
+				public constructor(param0: io.sentry.ILogger);
+				public serialize(param0: io.sentry.protocol.SentryId, param1: java.lang.reflect.Type, param2: com.google.gson.JsonSerializationContext): com.google.gson.JsonElement;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class SentryLevelDeserializerAdapter extends com.google.gson.JsonDeserializer<io.sentry.SentryLevel> {
+				public static class: java.lang.Class<io.sentry.adapters.SentryLevelDeserializerAdapter>;
+				public constructor(param0: io.sentry.ILogger);
+				public deserialize(param0: com.google.gson.JsonElement, param1: java.lang.reflect.Type, param2: com.google.gson.JsonDeserializationContext): io.sentry.SentryLevel;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class SentryLevelSerializerAdapter extends com.google.gson.JsonSerializer<io.sentry.SentryLevel> {
+				public static class: java.lang.Class<io.sentry.adapters.SentryLevelSerializerAdapter>;
+				public constructor(param0: io.sentry.ILogger);
+				public serialize(param0: io.sentry.SentryLevel, param1: java.lang.reflect.Type, param2: com.google.gson.JsonSerializationContext): com.google.gson.JsonElement;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class SpanIdDeserializerAdapter extends com.google.gson.JsonDeserializer<io.sentry.SpanId> {
+				public static class: java.lang.Class<io.sentry.adapters.SpanIdDeserializerAdapter>;
+				public deserialize(param0: com.google.gson.JsonElement, param1: java.lang.reflect.Type, param2: com.google.gson.JsonDeserializationContext): io.sentry.SpanId;
+				public constructor(param0: io.sentry.ILogger);
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class SpanIdSerializerAdapter extends com.google.gson.JsonSerializer<io.sentry.SpanId> {
+				public static class: java.lang.Class<io.sentry.adapters.SpanIdSerializerAdapter>;
+				public constructor(param0: io.sentry.ILogger);
+				public serialize(param0: io.sentry.SpanId, param1: java.lang.reflect.Type, param2: com.google.gson.JsonSerializationContext): com.google.gson.JsonElement;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class SpanStatusDeserializerAdapter extends com.google.gson.JsonDeserializer<io.sentry.SpanStatus> {
+				public static class: java.lang.Class<io.sentry.adapters.SpanStatusDeserializerAdapter>;
+				public constructor(param0: io.sentry.ILogger);
+				public deserialize(param0: com.google.gson.JsonElement, param1: java.lang.reflect.Type, param2: com.google.gson.JsonDeserializationContext): io.sentry.SpanStatus;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class SpanStatusSerializerAdapter extends com.google.gson.JsonSerializer<io.sentry.SpanStatus> {
+				public static class: java.lang.Class<io.sentry.adapters.SpanStatusSerializerAdapter>;
+				public constructor(param0: io.sentry.ILogger);
+				public serialize(param0: io.sentry.SpanStatus, param1: java.lang.reflect.Type, param2: com.google.gson.JsonSerializationContext): com.google.gson.JsonElement;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class TimeZoneDeserializerAdapter extends com.google.gson.JsonDeserializer<java.util.TimeZone> {
+				public static class: java.lang.Class<io.sentry.adapters.TimeZoneDeserializerAdapter>;
+				public constructor(param0: io.sentry.ILogger);
+				public deserialize(param0: com.google.gson.JsonElement, param1: java.lang.reflect.Type, param2: com.google.gson.JsonDeserializationContext): java.util.TimeZone;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module adapters {
+			export class TimeZoneSerializerAdapter extends com.google.gson.JsonSerializer<java.util.TimeZone> {
+				public static class: java.lang.Class<io.sentry.adapters.TimeZoneSerializerAdapter>;
+				public constructor(param0: io.sentry.ILogger);
+				public serialize(param0: java.util.TimeZone, param1: java.lang.reflect.Type, param2: com.google.gson.JsonSerializationContext): com.google.gson.JsonElement;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class ANRWatchDog {
+					public static class: java.lang.Class<io.sentry.android.core.ANRWatchDog>;
+					public run(): void;
+				}
+				export module ANRWatchDog {
+					export class ANRListener {
+						public static class: java.lang.Class<io.sentry.android.core.ANRWatchDog.ANRListener>;
+						/**
+						 * Constructs a new instance of the io.sentry.android.core.ANRWatchDog$ANRListener interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+						 */
+						public constructor(implementation: {
+							onAppNotResponding(param0: io.sentry.android.core.ApplicationNotResponding): void;
+						});
+						public constructor();
+						public onAppNotResponding(param0: io.sentry.android.core.ApplicationNotResponding): void;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class ActivityLifecycleIntegration extends io.sentry.Integration {
+					public static class: java.lang.Class<io.sentry.android.core.ActivityLifecycleIntegration>;
+					public onActivityPostResumed(param0: globalAndroid.app.Activity): void;
+					public onActivitySaveInstanceState(param0: globalAndroid.app.Activity, param1: globalAndroid.os.Bundle): void;
+					public onActivityStarted(param0: globalAndroid.app.Activity): void;
+					public onActivityCreated(param0: globalAndroid.app.Activity, param1: globalAndroid.os.Bundle): void;
+					public register(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): void;
+					public onActivityStopped(param0: globalAndroid.app.Activity): void;
+					public close(): void;
+					public onActivityPreCreated(param0: globalAndroid.app.Activity, param1: globalAndroid.os.Bundle): void;
+					public constructor(param0: globalAndroid.app.Application);
+					public onActivityResumed(param0: globalAndroid.app.Activity): void;
+					public onActivityPaused(param0: globalAndroid.app.Activity): void;
+					public onActivityDestroyed(param0: globalAndroid.app.Activity): void;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class AndroidLogger extends io.sentry.ILogger {
+					public static class: java.lang.Class<io.sentry.android.core.AndroidLogger>;
+					public log(param0: io.sentry.SentryLevel, param1: string, param2: java.lang.Throwable): void;
+					public log(param0: io.sentry.SentryLevel, param1: string, param2: androidNative.Array<any>): void;
+					public log(param0: io.sentry.SentryLevel, param1: java.lang.Throwable, param2: string, param3: androidNative.Array<any>): void;
+					public isEnabled(param0: io.sentry.SentryLevel): boolean;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class AndroidOptionsInitializer {
+					public static class: java.lang.Class<io.sentry.android.core.AndroidOptionsInitializer>;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class AndroidTransportGate extends io.sentry.transport.ITransportGate {
+					public static class: java.lang.Class<io.sentry.android.core.AndroidTransportGate>;
+					public isConnected(): boolean;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class AnrIntegration extends io.sentry.Integration {
+					public static class: java.lang.Class<io.sentry.android.core.AnrIntegration>;
+					public constructor(param0: globalAndroid.content.Context);
+					public register(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): void;
+					public close(): void;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class AppComponentsBreadcrumbsIntegration extends io.sentry.Integration {
+					public static class: java.lang.Class<io.sentry.android.core.AppComponentsBreadcrumbsIntegration>;
+					public constructor(param0: globalAndroid.content.Context);
+					public register(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): void;
+					public onTrimMemory(param0: number): void;
+					public close(): void;
+					public onConfigurationChanged(param0: globalAndroid.content.res.Configuration): void;
+					public onLowMemory(): void;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class AppLifecycleIntegration extends io.sentry.Integration {
+					public static class: java.lang.Class<io.sentry.android.core.AppLifecycleIntegration>;
+					public register(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): void;
+					public constructor();
+					public close(): void;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class ApplicationNotResponding {
+					public static class: java.lang.Class<io.sentry.android.core.ApplicationNotResponding>;
+					public getThread(): java.lang.Thread;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class BuildConfig {
+					public static class: java.lang.Class<io.sentry.android.core.BuildConfig>;
+					public static DEBUG: boolean;
+					public static LIBRARY_PACKAGE_NAME: string;
+					public static BUILD_TYPE: string;
+					public static SENTRY_ANDROID_SDK_NAME: string;
+					public static VERSION_NAME: string;
+					public constructor();
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class BuildInfoProvider extends io.sentry.android.core.IBuildInfoProvider {
+					public static class: java.lang.Class<io.sentry.android.core.BuildInfoProvider>;
+					public constructor();
+					public getSdkInfoVersion(): number;
+					public getBuildTags(): string;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class ContextUtils {
+					public static class: java.lang.Class<io.sentry.android.core.ContextUtils>;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class DefaultAndroidEventProcessor extends io.sentry.EventProcessor {
+					public static class: java.lang.Class<io.sentry.android.core.DefaultAndroidEventProcessor>;
+					public process(param0: io.sentry.SentryEvent, param1: any): io.sentry.SentryEvent;
+					public getDefaultUser(): io.sentry.protocol.User;
+					public constructor(param0: globalAndroid.content.Context, param1: io.sentry.ILogger, param2: io.sentry.android.core.IBuildInfoProvider);
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class EnvelopeFileObserver {
+					public static class: java.lang.Class<io.sentry.android.core.EnvelopeFileObserver>;
+					public onEvent(param0: number, param1: string): void;
+				}
+				export module EnvelopeFileObserver {
+					export class CachedEnvelopeHint implements io.sentry.hints.Cached, io.sentry.hints.Retryable, io.sentry.hints.SubmissionResult, io.sentry.hints.Flushable, io.sentry.hints.ApplyScopeData, io.sentry.hints.Resettable {
+						public static class: java.lang.Class<io.sentry.android.core.EnvelopeFileObserver.CachedEnvelopeHint>;
+						public isRetry(): boolean;
+						public waitFlush(): boolean;
+						public isSuccess(): boolean;
+						public setResult(param0: boolean): void;
+						public setRetry(param0: boolean): void;
+						public constructor(param0: number, param1: io.sentry.ILogger);
+						public reset(): void;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export abstract class EnvelopeFileObserverIntegration extends io.sentry.Integration {
+					public static class: java.lang.Class<io.sentry.android.core.EnvelopeFileObserverIntegration>;
+					public register(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): void;
+					public constructor();
+					public close(): void;
+					public static getOutboxFileObserver(): io.sentry.android.core.EnvelopeFileObserverIntegration;
+				}
+				export module EnvelopeFileObserverIntegration {
+					export class OutboxEnvelopeFileObserverIntegration extends io.sentry.android.core.EnvelopeFileObserverIntegration {
+						public static class: java.lang.Class<io.sentry.android.core.EnvelopeFileObserverIntegration.OutboxEnvelopeFileObserverIntegration>;
+						public register(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): void;
+						public getPath(param0: io.sentry.SentryOptions): string;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class IBuildInfoProvider {
+					public static class: java.lang.Class<io.sentry.android.core.IBuildInfoProvider>;
+					/**
+					 * Constructs a new instance of the io.sentry.android.core.IBuildInfoProvider interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+					 */
+					public constructor(implementation: {
+						getSdkInfoVersion(): number;
+						getBuildTags(): string;
+					});
+					public constructor();
+					public getSdkInfoVersion(): number;
+					public getBuildTags(): string;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class IDebugImagesLoader {
+					public static class: java.lang.Class<io.sentry.android.core.IDebugImagesLoader>;
+					/**
+					 * Constructs a new instance of the io.sentry.android.core.IDebugImagesLoader interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+					 */
+					public constructor(implementation: {
+						loadDebugImages(): java.util.List<io.sentry.protocol.DebugImage>;
+						clearDebugImages(): void;
+					});
+					public constructor();
+					public loadDebugImages(): java.util.List<io.sentry.protocol.DebugImage>;
+					public clearDebugImages(): void;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class IHandler {
+					public static class: java.lang.Class<io.sentry.android.core.IHandler>;
+					/**
+					 * Constructs a new instance of the io.sentry.android.core.IHandler interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+					 */
+					public constructor(implementation: {
+						post(param0: java.lang.Runnable): void;
+						getThread(): java.lang.Thread;
+					});
+					public constructor();
+					public post(param0: java.lang.Runnable): void;
+					public getThread(): java.lang.Thread;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class ILoadClass {
+					public static class: java.lang.Class<io.sentry.android.core.ILoadClass>;
+					/**
+					 * Constructs a new instance of the io.sentry.android.core.ILoadClass interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+					 */
+					public constructor(implementation: {
+						loadClass(param0: string): java.lang.Class<any>;
+					});
+					public constructor();
+					public loadClass(param0: string): java.lang.Class<any>;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class Installation {
+					public static class: java.lang.Class<io.sentry.android.core.Installation>;
+					public static id(param0: globalAndroid.content.Context): string;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class LifecycleWatcher {
+					public static class: java.lang.Class<io.sentry.android.core.LifecycleWatcher>;
+					public onStart(param0: androidx.lifecycle.LifecycleOwner): void;
+					public onStop(param0: androidx.lifecycle.LifecycleOwner): void;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class LoadClass extends io.sentry.android.core.ILoadClass {
+					public static class: java.lang.Class<io.sentry.android.core.LoadClass>;
+					public loadClass(param0: string): java.lang.Class<any>;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class MainLooperHandler extends io.sentry.android.core.IHandler {
+					public static class: java.lang.Class<io.sentry.android.core.MainLooperHandler>;
+					public post(param0: java.lang.Runnable): void;
+					public getThread(): java.lang.Thread;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class ManifestMetadataReader {
+					public static class: java.lang.Class<io.sentry.android.core.ManifestMetadataReader>;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class NdkIntegration extends io.sentry.Integration {
+					public static class: java.lang.Class<io.sentry.android.core.NdkIntegration>;
+					public static SENTRY_NDK_CLASS_NAME: string;
+					public constructor(param0: java.lang.Class<any>);
+					public register(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): void;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class NoOpDebugImagesLoader extends io.sentry.android.core.IDebugImagesLoader {
+					public static class: java.lang.Class<io.sentry.android.core.NoOpDebugImagesLoader>;
+					public loadDebugImages(): java.util.List<io.sentry.protocol.DebugImage>;
+					public clearDebugImages(): void;
+					public static getInstance(): io.sentry.android.core.NoOpDebugImagesLoader;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class PhoneStateBreadcrumbsIntegration extends io.sentry.Integration {
+					public static class: java.lang.Class<io.sentry.android.core.PhoneStateBreadcrumbsIntegration>;
+					public constructor(param0: globalAndroid.content.Context);
+					public register(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): void;
+					public close(): void;
+				}
+				export module PhoneStateBreadcrumbsIntegration {
+					export class PhoneStateChangeListener {
+						public static class: java.lang.Class<io.sentry.android.core.PhoneStateBreadcrumbsIntegration.PhoneStateChangeListener>;
+						public onCallStateChanged(param0: number, param1: string): void;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class SentryAndroid {
+					public static class: java.lang.Class<io.sentry.android.core.SentryAndroid>;
+					public static init(param0: globalAndroid.content.Context): void;
+					public static init(param0: globalAndroid.content.Context, param1: io.sentry.ILogger): void;
+					public static init(param0: globalAndroid.content.Context, param1: io.sentry.Sentry.OptionsConfiguration<io.sentry.android.core.SentryAndroidOptions>): void;
+					public static init(param0: globalAndroid.content.Context, param1: io.sentry.ILogger, param2: io.sentry.Sentry.OptionsConfiguration<io.sentry.android.core.SentryAndroidOptions>): void;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class SentryAndroidOptions extends io.sentry.SentryOptions {
+					public static class: java.lang.Class<io.sentry.android.core.SentryAndroidOptions>;
+					public getDebugImagesLoader(): io.sentry.android.core.IDebugImagesLoader;
+					public setEnableAutoActivityLifecycleTracing(param0: boolean): void;
+					public isAnrReportInDebug(): boolean;
+					public setDebugImagesLoader(param0: io.sentry.android.core.IDebugImagesLoader): void;
+					public isEnableAutoActivityLifecycleTracing(): boolean;
+					public setEnableAppComponentBreadcrumbs(param0: boolean): void;
+					public isEnableSystemEventBreadcrumbs(): boolean;
+					public enableAllAutoBreadcrumbs(param0: boolean): void;
+					public isEnableAppLifecycleBreadcrumbs(): boolean;
+					public isEnableActivityLifecycleBreadcrumbs(): boolean;
+					public setAnrReportInDebug(param0: boolean): void;
+					public setAnrTimeoutIntervalMillis(param0: number): void;
+					public setEnableSystemEventBreadcrumbs(param0: boolean): void;
+					public setEnableActivityLifecycleTracingAutoFinish(param0: boolean): void;
+					public constructor();
+					public setEnableActivityLifecycleBreadcrumbs(param0: boolean): void;
+					public isEnableActivityLifecycleTracingAutoFinish(): boolean;
+					public isAnrEnabled(): boolean;
+					public getAnrTimeoutIntervalMillis(): number;
+					public setAnrEnabled(param0: boolean): void;
+					public setEnableAppLifecycleBreadcrumbs(param0: boolean): void;
+					public isEnableAppComponentBreadcrumbs(): boolean;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class SentryInitProvider {
+					public static class: java.lang.Class<io.sentry.android.core.SentryInitProvider>;
+					public shutdown(): void;
+					public delete(param0: globalAndroid.net.Uri, param1: string, param2: androidNative.Array<string>): number;
+					public attachInfo(param0: globalAndroid.content.Context, param1: globalAndroid.content.pm.ProviderInfo): void;
+					public constructor();
+					public query(param0: globalAndroid.net.Uri, param1: androidNative.Array<string>, param2: string, param3: androidNative.Array<string>, param4: string): globalAndroid.database.Cursor;
+					public update(param0: globalAndroid.net.Uri, param1: globalAndroid.content.ContentValues, param2: string, param3: androidNative.Array<string>): number;
+					public onCreate(): boolean;
+					public getType(param0: globalAndroid.net.Uri): string;
+					public insert(param0: globalAndroid.net.Uri, param1: globalAndroid.content.ContentValues): globalAndroid.net.Uri;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class SystemEventsBreadcrumbsIntegration extends io.sentry.Integration {
+					public static class: java.lang.Class<io.sentry.android.core.SystemEventsBreadcrumbsIntegration>;
+					public constructor(param0: globalAndroid.content.Context);
+					public register(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): void;
+					public close(): void;
+					public constructor(param0: globalAndroid.content.Context, param1: java.util.List<string>);
+				}
+				export module SystemEventsBreadcrumbsIntegration {
+					export class SystemEventsBroadcastReceiver {
+						public static class: java.lang.Class<io.sentry.android.core.SystemEventsBreadcrumbsIntegration.SystemEventsBroadcastReceiver>;
+						public onReceive(param0: globalAndroid.content.Context, param1: globalAndroid.content.Intent): void;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export class TempSensorBreadcrumbsIntegration extends io.sentry.Integration {
+					public static class: java.lang.Class<io.sentry.android.core.TempSensorBreadcrumbsIntegration>;
+					public constructor(param0: globalAndroid.content.Context);
+					public onSensorChanged(param0: globalAndroid.hardware.SensorEvent): void;
+					public register(param0: io.sentry.IHub, param1: io.sentry.SentryOptions): void;
+					public onAccuracyChanged(param0: globalAndroid.hardware.Sensor, param1: number): void;
+					public close(): void;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export module util {
+					export class ConnectivityChecker {
+						public static class: java.lang.Class<io.sentry.android.core.util.ConnectivityChecker>;
+						public static getConnectionStatus(param0: globalAndroid.content.Context, param1: io.sentry.ILogger): io.sentry.android.core.util.ConnectivityChecker.Status;
+						public static getConnectionType(param0: globalAndroid.content.Context, param1: io.sentry.ILogger, param2: io.sentry.android.core.IBuildInfoProvider): string;
+					}
+					export module ConnectivityChecker {
+						export class Status {
+							public static class: java.lang.Class<io.sentry.android.core.util.ConnectivityChecker.Status>;
+							public static CONNECTED: io.sentry.android.core.util.ConnectivityChecker.Status;
+							public static NOT_CONNECTED: io.sentry.android.core.util.ConnectivityChecker.Status;
+							public static NO_PERMISSION: io.sentry.android.core.util.ConnectivityChecker.Status;
+							public static UNKNOWN: io.sentry.android.core.util.ConnectivityChecker.Status;
+							public static values(): androidNative.Array<io.sentry.android.core.util.ConnectivityChecker.Status>;
+							public static valueOf(param0: string): io.sentry.android.core.util.ConnectivityChecker.Status;
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export module util {
+					export class DeviceOrientations {
+						public static class: java.lang.Class<io.sentry.android.core.util.DeviceOrientations>;
+						public static getOrientation(param0: number): io.sentry.protocol.Device.DeviceOrientation;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export module util {
+					export class MainThreadChecker {
+						public static class: java.lang.Class<io.sentry.android.core.util.MainThreadChecker>;
+						public static isMainThread(): boolean;
+						public static isMainThread(param0: java.lang.Thread): boolean;
+						public static isMainThread(param0: io.sentry.protocol.SentryThread): boolean;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export module util {
+					export class Permissions {
+						public static class: java.lang.Class<io.sentry.android.core.util.Permissions>;
+						public static hasPermission(param0: globalAndroid.content.Context, param1: string): boolean;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module android {
+			export module core {
+				export module util {
+					export class RootChecker {
+						public static class: java.lang.Class<io.sentry.android.core.util.RootChecker>;
+						public constructor(param0: globalAndroid.content.Context, param1: io.sentry.android.core.IBuildInfoProvider, param2: io.sentry.ILogger);
+						public isDeviceRooted(): boolean;
+					}
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module cache {
+			export abstract class CacheStrategy {
+				public static class: java.lang.Class<io.sentry.cache.CacheStrategy>;
+				public static UTF_8: java.nio.charset.Charset;
+				public options: io.sentry.SentryOptions;
+				public serializer: io.sentry.ISerializer;
+				public directory: java.io.File;
+				public rotateCacheIfNeeded(param0: androidNative.Array<java.io.File>): void;
+				public isDirectoryValid(): boolean;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module cache {
+			export class EnvelopeCache extends io.sentry.cache.CacheStrategy implements io.sentry.cache.IEnvelopeCache {
+				public static class: java.lang.Class<io.sentry.cache.EnvelopeCache>;
+				public static SUFFIX_ENVELOPE_FILE: string;
+				public static PREFIX_CURRENT_SESSION_FILE: string;
+				public constructor(param0: io.sentry.SentryOptions);
+				public discard(param0: io.sentry.SentryEnvelope): void;
+				public store(param0: io.sentry.SentryEnvelope, param1: any): void;
+				public store(param0: io.sentry.SentryEnvelope): void;
+				public iterator(): java.util.Iterator<io.sentry.SentryEnvelope>;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module cache {
+			export class IEnvelopeCache extends java.lang.Iterable<io.sentry.SentryEnvelope> {
+				public static class: java.lang.Class<io.sentry.cache.IEnvelopeCache>;
+				/**
+				 * Constructs a new instance of the io.sentry.cache.IEnvelopeCache interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					store(param0: io.sentry.SentryEnvelope, param1: any): void;
+					store(param0: io.sentry.SentryEnvelope): void;
+					discard(param0: io.sentry.SentryEnvelope): void;
+				});
+				public constructor();
+				public discard(param0: io.sentry.SentryEnvelope): void;
+				public store(param0: io.sentry.SentryEnvelope, param1: any): void;
+				public store(param0: io.sentry.SentryEnvelope): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module config {
+			export abstract class AbstractPropertiesProvider extends io.sentry.config.PropertiesProvider {
+				public static class: java.lang.Class<io.sentry.config.AbstractPropertiesProvider>;
+				public constructor(param0: string, param1: java.util.Properties);
+				public getProperty(param0: string, param1: string): string;
+				public getMap(param0: string): java.util.Map<string,string>;
+				public getDoubleProperty(param0: string): java.lang.Double;
+				public getProperty(param0: string): string;
+				public getList(param0: string): java.util.List<string>;
+				public constructor(param0: java.util.Properties);
+				public getBooleanProperty(param0: string): java.lang.Boolean;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module config {
+			export class ClasspathPropertiesLoader extends io.sentry.config.PropertiesLoader {
+				public static class: java.lang.Class<io.sentry.config.ClasspathPropertiesLoader>;
+				public constructor(param0: string, param1: java.lang.ClassLoader, param2: io.sentry.ILogger);
+				public constructor(param0: io.sentry.ILogger);
+				public load(): java.util.Properties;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module config {
+			export class CompositePropertiesProvider extends io.sentry.config.PropertiesProvider {
+				public static class: java.lang.Class<io.sentry.config.CompositePropertiesProvider>;
+				public getProperty(param0: string, param1: string): string;
+				public getMap(param0: string): java.util.Map<string,string>;
+				public constructor(param0: java.util.List<io.sentry.config.PropertiesProvider>);
+				public getDoubleProperty(param0: string): java.lang.Double;
+				public getProperty(param0: string): string;
+				public getList(param0: string): java.util.List<string>;
+				public getBooleanProperty(param0: string): java.lang.Boolean;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module config {
+			export class EnvironmentVariablePropertiesProvider extends io.sentry.config.PropertiesProvider {
+				public static class: java.lang.Class<io.sentry.config.EnvironmentVariablePropertiesProvider>;
+				public getProperty(param0: string, param1: string): string;
+				public getMap(param0: string): java.util.Map<string,string>;
+				public getDoubleProperty(param0: string): java.lang.Double;
+				public getProperty(param0: string): string;
+				public getList(param0: string): java.util.List<string>;
+				public getBooleanProperty(param0: string): java.lang.Boolean;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module config {
+			export class FilesystemPropertiesLoader extends io.sentry.config.PropertiesLoader {
+				public static class: java.lang.Class<io.sentry.config.FilesystemPropertiesLoader>;
+				public constructor(param0: string, param1: io.sentry.ILogger);
+				public load(): java.util.Properties;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module config {
+			export class PropertiesLoader {
+				public static class: java.lang.Class<io.sentry.config.PropertiesLoader>;
+				/**
+				 * Constructs a new instance of the io.sentry.config.PropertiesLoader interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					load(): java.util.Properties;
+				});
+				public constructor();
+				public load(): java.util.Properties;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module config {
+			export class PropertiesProvider {
+				public static class: java.lang.Class<io.sentry.config.PropertiesProvider>;
+				/**
+				 * Constructs a new instance of the io.sentry.config.PropertiesProvider interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					getProperty(param0: string): string;
+					getMap(param0: string): java.util.Map<string,string>;
+					getList(param0: string): java.util.List<string>;
+					getProperty(param0: string, param1: string): string;
+					getBooleanProperty(param0: string): java.lang.Boolean;
+					getDoubleProperty(param0: string): java.lang.Double;
+				});
+				public constructor();
+				public getProperty(param0: string, param1: string): string;
+				public getMap(param0: string): java.util.Map<string,string>;
+				public getDoubleProperty(param0: string): java.lang.Double;
+				public getProperty(param0: string): string;
+				public getList(param0: string): java.util.List<string>;
+				public getBooleanProperty(param0: string): java.lang.Boolean;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module config {
+			export class PropertiesProviderFactory {
+				public static class: java.lang.Class<io.sentry.config.PropertiesProviderFactory>;
+				public static create(): io.sentry.config.PropertiesProvider;
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module config {
+			export class SimplePropertiesProvider extends io.sentry.config.AbstractPropertiesProvider {
+				public static class: java.lang.Class<io.sentry.config.SimplePropertiesProvider>;
+				public constructor(param0: string, param1: java.util.Properties);
+				public getProperty(param0: string, param1: string): string;
+				public getMap(param0: string): java.util.Map<string,string>;
+				public getDoubleProperty(param0: string): java.lang.Double;
+				public getProperty(param0: string): string;
+				public getList(param0: string): java.util.List<string>;
+				public constructor(param0: java.util.Properties);
+				public getBooleanProperty(param0: string): java.lang.Boolean;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module config {
+			export class SystemPropertyPropertiesProvider extends io.sentry.config.AbstractPropertiesProvider {
+				public static class: java.lang.Class<io.sentry.config.SystemPropertyPropertiesProvider>;
+				public constructor(param0: string, param1: java.util.Properties);
+				public getProperty(param0: string, param1: string): string;
+				public getMap(param0: string): java.util.Map<string,string>;
+				public getDoubleProperty(param0: string): java.lang.Double;
+				public getProperty(param0: string): string;
+				public getList(param0: string): java.util.List<string>;
+				public constructor(param0: java.util.Properties);
+				public getBooleanProperty(param0: string): java.lang.Boolean;
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module exception {
+			export class ExceptionMechanismException {
+				public static class: java.lang.Class<io.sentry.exception.ExceptionMechanismException>;
+				public getThread(): java.lang.Thread;
+				public isSnapshot(): boolean;
+				public constructor(param0: io.sentry.protocol.Mechanism, param1: java.lang.Throwable, param2: java.lang.Thread);
+				public getExceptionMechanism(): io.sentry.protocol.Mechanism;
+				public constructor(param0: io.sentry.protocol.Mechanism, param1: java.lang.Throwable, param2: java.lang.Thread, param3: boolean);
+				public getThrowable(): java.lang.Throwable;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module exception {
+			export class InvalidDsnException {
+				public static class: java.lang.Class<io.sentry.exception.InvalidDsnException>;
+				public getDsn(): string;
+				public constructor(param0: string, param1: java.lang.Throwable);
+				public constructor(param0: string);
+				public constructor(param0: string, param1: string);
+				public constructor(param0: string, param1: string, param2: java.lang.Throwable);
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module exception {
+			export class InvalidSentryTraceHeaderException {
+				public static class: java.lang.Class<io.sentry.exception.InvalidSentryTraceHeaderException>;
+				public getSentryTraceHeader(): string;
+				public constructor(param0: string);
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module exception {
+			export class SentryEnvelopeException {
+				public static class: java.lang.Class<io.sentry.exception.SentryEnvelopeException>;
+				public constructor(param0: string);
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module hints {
+			export class ApplyScopeData {
+				public static class: java.lang.Class<io.sentry.hints.ApplyScopeData>;
+				/**
+				 * Constructs a new instance of the io.sentry.hints.ApplyScopeData interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+				});
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module hints {
+			export class Cached {
+				public static class: java.lang.Class<io.sentry.hints.Cached>;
+				/**
+				 * Constructs a new instance of the io.sentry.hints.Cached interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+				});
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module hints {
+			export class DiskFlushNotification {
+				public static class: java.lang.Class<io.sentry.hints.DiskFlushNotification>;
+				/**
+				 * Constructs a new instance of the io.sentry.hints.DiskFlushNotification interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					markFlushed(): void;
+				});
+				public constructor();
+				public markFlushed(): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module hints {
+			export class Flushable {
+				public static class: java.lang.Class<io.sentry.hints.Flushable>;
+				/**
+				 * Constructs a new instance of the io.sentry.hints.Flushable interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					waitFlush(): boolean;
+				});
+				public constructor();
+				public waitFlush(): boolean;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module hints {
+			export class Resettable {
+				public static class: java.lang.Class<io.sentry.hints.Resettable>;
+				/**
+				 * Constructs a new instance of the io.sentry.hints.Resettable interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					reset(): void;
+				});
+				public constructor();
+				public reset(): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module hints {
+			export class Retryable {
+				public static class: java.lang.Class<io.sentry.hints.Retryable>;
+				/**
+				 * Constructs a new instance of the io.sentry.hints.Retryable interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					isRetry(): boolean;
+					setRetry(param0: boolean): void;
+				});
+				public constructor();
+				public isRetry(): boolean;
+				public setRetry(param0: boolean): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module hints {
+			export class SessionEnd {
+				public static class: java.lang.Class<io.sentry.hints.SessionEnd>;
+				/**
+				 * Constructs a new instance of the io.sentry.hints.SessionEnd interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+				});
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module hints {
+			export class SessionEndHint extends io.sentry.hints.SessionEnd {
+				public static class: java.lang.Class<io.sentry.hints.SessionEndHint>;
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module hints {
+			export class SessionStart {
+				public static class: java.lang.Class<io.sentry.hints.SessionStart>;
+				/**
+				 * Constructs a new instance of the io.sentry.hints.SessionStart interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+				});
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module hints {
+			export class SessionStartHint extends io.sentry.hints.SessionStart {
+				public static class: java.lang.Class<io.sentry.hints.SessionStartHint>;
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module hints {
+			export class SubmissionResult {
+				public static class: java.lang.Class<io.sentry.hints.SubmissionResult>;
+				/**
+				 * Constructs a new instance of the io.sentry.hints.SubmissionResult interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					setResult(param0: boolean): void;
+					isSuccess(): boolean;
+				});
+				public constructor();
+				public setResult(param0: boolean): void;
+				public isSuccess(): boolean;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class App extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.App>;
+				public static TYPE: string;
+				public clone(): io.sentry.protocol.App;
+				public setAppIdentifier(param0: string): void;
+				public getAppIdentifier(): string;
+				public setAppVersion(param0: string): void;
+				public setAppBuild(param0: string): void;
+				public getAppBuild(): string;
+				public setAppName(param0: string): void;
+				public getAppStartTime(): java.util.Date;
+				public getDeviceAppHash(): string;
+				public constructor();
+				public getAppVersion(): string;
+				public getBuildType(): string;
+				public getAppName(): string;
+				public setBuildType(param0: string): void;
+				public setDeviceAppHash(param0: string): void;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public setAppStartTime(param0: java.util.Date): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class Browser extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.Browser>;
+				public static TYPE: string;
+				public setName(param0: string): void;
+				public getVersion(): string;
+				public clone(): io.sentry.protocol.Browser;
+				public getName(): string;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public setVersion(param0: string): void;
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class Contexts extends java.util.concurrent.ConcurrentHashMap<string,any> implements java.lang.Cloneable  {
+				public static class: java.lang.Class<io.sentry.protocol.Contexts>;
+				public getOperatingSystem(): io.sentry.protocol.OperatingSystem;
+				public getDevice(): io.sentry.protocol.Device;
+				public setApp(param0: io.sentry.protocol.App): void;
+				public constructor();
+				public setDevice(param0: io.sentry.protocol.Device): void;
+				public getRuntime(): io.sentry.protocol.SentryRuntime;
+				public getGpu(): io.sentry.protocol.Gpu;
+				public getTrace(): io.sentry.SpanContext;
+				public clone(): io.sentry.protocol.Contexts;
+				public setGpu(param0: io.sentry.protocol.Gpu): void;
+				public getApp(): io.sentry.protocol.App;
+				public setTrace(param0: io.sentry.SpanContext): void;
+				public setBrowser(param0: io.sentry.protocol.Browser): void;
+				public setRuntime(param0: io.sentry.protocol.SentryRuntime): void;
+				public getBrowser(): io.sentry.protocol.Browser;
+				public setOperatingSystem(param0: io.sentry.protocol.OperatingSystem): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class DebugImage extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.DebugImage>;
+				public getUuid(): string;
+				public setUuid(param0: string): void;
+				public getType(): string;
+				public setImageSize(param0: number): void;
+				public setArch(param0: string): void;
+				public getCodeId(): string;
+				public getDebugFile(): string;
+				public setCodeFile(param0: string): void;
+				public getDebugId(): string;
+				public getImageSize(): java.lang.Long;
+				public setType(param0: string): void;
+				public getArch(): string;
+				public constructor();
+				public setImageAddr(param0: string): void;
+				public setImageSize(param0: java.lang.Long): void;
+				public setDebugFile(param0: string): void;
+				public setDebugId(param0: string): void;
+				public getImageAddr(): string;
+				public setCodeId(param0: string): void;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public getCodeFile(): string;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class DebugMeta extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.DebugMeta>;
+				public getImages(): java.util.List<io.sentry.protocol.DebugImage>;
+				public setImages(param0: java.util.List<io.sentry.protocol.DebugImage>): void;
+				public getSdkInfo(): io.sentry.protocol.SdkInfo;
+				public setSdkInfo(param0: io.sentry.protocol.SdkInfo): void;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class Device extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.Device>;
+				public static TYPE: string;
+				public setMemorySize(param0: java.lang.Long): void;
+				public setFreeStorage(param0: java.lang.Long): void;
+				public setScreenDpi(param0: java.lang.Integer): void;
+				public getId(): string;
+				public getFreeMemory(): java.lang.Long;
+				public setCharging(param0: java.lang.Boolean): void;
+				public setExternalStorageSize(param0: java.lang.Long): void;
+				public setArchs(param0: androidNative.Array<string>): void;
+				public getExternalStorageSize(): java.lang.Long;
+				public getBrand(): string;
+				public constructor();
+				public setBatteryTemperature(param0: java.lang.Float): void;
+				public isOnline(): java.lang.Boolean;
+				public setBrand(param0: string): void;
+				public getScreenWidthPixels(): java.lang.Integer;
+				public getStorageSize(): java.lang.Long;
+				public getTimezone(): java.util.TimeZone;
+				public setScreenDensity(param0: java.lang.Float): void;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public setName(param0: string): void;
+				public setManufacturer(param0: string): void;
+				public getMemorySize(): java.lang.Long;
+				public setFamily(param0: string): void;
+				public getName(): string;
+				public setBatteryLevel(param0: java.lang.Float): void;
+				public getArchs(): androidNative.Array<string>;
+				public getBootTime(): java.util.Date;
+				public clone(): io.sentry.protocol.Device;
+				public setOnline(param0: java.lang.Boolean): void;
+				public setStorageSize(param0: java.lang.Long): void;
+				public isLowMemory(): java.lang.Boolean;
+				public getLanguage(): string;
+				public getScreenDpi(): java.lang.Integer;
+				public setModelId(param0: string): void;
+				public setConnectionType(param0: string): void;
+				public setFreeMemory(param0: java.lang.Long): void;
+				public getModelId(): string;
+				public setLowMemory(param0: java.lang.Boolean): void;
+				public getScreenDensity(): java.lang.Float;
+				public setModel(param0: string): void;
+				public setTimezone(param0: java.util.TimeZone): void;
+				public getFamily(): string;
+				public setScreenHeightPixels(param0: java.lang.Integer): void;
+				public setUsableMemory(param0: java.lang.Long): void;
+				public isCharging(): java.lang.Boolean;
+				public setExternalFreeStorage(param0: java.lang.Long): void;
+				public setId(param0: string): void;
+				public getExternalFreeStorage(): java.lang.Long;
+				public getFreeStorage(): java.lang.Long;
+				public getScreenHeightPixels(): java.lang.Integer;
+				public getOrientation(): io.sentry.protocol.Device.DeviceOrientation;
+				public getBatteryLevel(): java.lang.Float;
+				public getModel(): string;
+				public getBatteryTemperature(): java.lang.Float;
+				public setBootTime(param0: java.util.Date): void;
+				public getConnectionType(): string;
+				public setScreenWidthPixels(param0: java.lang.Integer): void;
+				public setOrientation(param0: io.sentry.protocol.Device.DeviceOrientation): void;
+				public getManufacturer(): string;
+				public setSimulator(param0: java.lang.Boolean): void;
+				public setLanguage(param0: string): void;
+				public isSimulator(): java.lang.Boolean;
+				public getUsableMemory(): java.lang.Long;
+			}
+			export module Device {
+				export class DeviceOrientation {
+					public static class: java.lang.Class<io.sentry.protocol.Device.DeviceOrientation>;
+					public static PORTRAIT: io.sentry.protocol.Device.DeviceOrientation;
+					public static LANDSCAPE: io.sentry.protocol.Device.DeviceOrientation;
+					public static valueOf(param0: string): io.sentry.protocol.Device.DeviceOrientation;
+					public static values(): androidNative.Array<io.sentry.protocol.Device.DeviceOrientation>;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class Gpu extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.Gpu>;
+				public static TYPE: string;
+				public setName(param0: string): void;
+				public setApiType(param0: string): void;
+				public getVendorName(): string;
+				public setMemorySize(param0: java.lang.Integer): void;
+				public setNpotSupport(param0: string): void;
+				public getName(): string;
+				public isMultiThreadedRendering(): java.lang.Boolean;
+				public setVersion(param0: string): void;
+				public getId(): java.lang.Integer;
+				public constructor();
+				public setVendorId(param0: java.lang.Integer): void;
+				public clone(): io.sentry.protocol.Gpu;
+				public getApiType(): string;
+				public getVersion(): string;
+				public setId(param0: java.lang.Integer): void;
+				public setMultiThreadedRendering(param0: java.lang.Boolean): void;
+				public setVendorName(param0: string): void;
+				public getMemorySize(): java.lang.Integer;
+				public getVendorId(): java.lang.Integer;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public getNpotSupport(): string;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class Mechanism extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.Mechanism>;
+				public setData(param0: java.util.Map<string,any>): void;
+				public setSynthetic(param0: java.lang.Boolean): void;
+				public getType(): string;
+				public isHandled(): java.lang.Boolean;
+				public constructor(param0: java.lang.Thread);
+				public setMeta(param0: java.util.Map<string,any>): void;
+				public getHelpLink(): string;
+				public setType(param0: string): void;
+				public getDescription(): string;
+				public getMeta(): java.util.Map<string,any>;
+				public getData(): java.util.Map<string,any>;
+				public setHelpLink(param0: string): void;
+				public constructor();
+				public setDescription(param0: string): void;
+				public setHandled(param0: java.lang.Boolean): void;
+				public getSynthetic(): java.lang.Boolean;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class Message extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.Message>;
+				public getFormatted(): string;
+				public setParams(param0: java.util.List<string>): void;
+				public setMessage(param0: string): void;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public getMessage(): string;
+				public getParams(): java.util.List<string>;
+				public setFormatted(param0: string): void;
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class OperatingSystem extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.OperatingSystem>;
+				public static TYPE: string;
+				public setName(param0: string): void;
+				public getRawDescription(): string;
+				public isRooted(): java.lang.Boolean;
+				public getBuild(): string;
+				public setRooted(param0: java.lang.Boolean): void;
+				public getName(): string;
+				public setVersion(param0: string): void;
+				public constructor();
+				public getVersion(): string;
+				public setBuild(param0: string): void;
+				public getKernelVersion(): string;
+				public clone(): io.sentry.protocol.OperatingSystem;
+				public setRawDescription(param0: string): void;
+				public setKernelVersion(param0: string): void;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class Request extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.Request>;
+				public getCookies(): string;
+				public clone(): io.sentry.protocol.Request;
+				public setMethod(param0: string): void;
+				public getOthers(): java.util.Map<string,string>;
+				public setHeaders(param0: java.util.Map<string,string>): void;
+				public getUrl(): string;
+				public getData(): any;
+				public setCookies(param0: string): void;
+				public constructor();
+				public getMethod(): string;
+				public setData(param0: any): void;
+				public getEnvs(): java.util.Map<string,string>;
+				public getHeaders(): java.util.Map<string,string>;
+				public getQueryString(): string;
+				public setEnvs(param0: java.util.Map<string,string>): void;
+				public setQueryString(param0: string): void;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public setUrl(param0: string): void;
+				public setOthers(param0: java.util.Map<string,string>): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class SdkInfo extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.SdkInfo>;
+				public setSdkName(param0: string): void;
+				public getVersionMinor(): java.lang.Integer;
+				public setVersionPatchlevel(param0: java.lang.Integer): void;
+				public setVersionMajor(param0: java.lang.Integer): void;
+				public setVersionMinor(param0: java.lang.Integer): void;
+				public getSdkName(): string;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public getVersionMajor(): java.lang.Integer;
+				public constructor();
+				public getVersionPatchlevel(): java.lang.Integer;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class SdkVersion extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.SdkVersion>;
+				public getVersion(): string;
+				public setName(param0: string): void;
+				public static updateSdkVersion(param0: io.sentry.protocol.SdkVersion, param1: string, param2: string): io.sentry.protocol.SdkVersion;
+				/** @deprecated */
+				public constructor();
+				public getIntegrations(): java.util.List<string>;
+				public getName(): string;
+				public getPackages(): java.util.List<io.sentry.protocol.SentryPackage>;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public setVersion(param0: string): void;
+				public addIntegration(param0: string): void;
+				public addPackage(param0: string, param1: string): void;
+				public constructor(param0: string, param1: string);
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class SentryException extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.SentryException>;
+				public getType(): string;
+				public getModule(): string;
+				public getMechanism(): io.sentry.protocol.Mechanism;
+				public setModule(param0: string): void;
+				public getValue(): string;
+				public setType(param0: string): void;
+				public constructor();
+				public setValue(param0: string): void;
+				public setThreadId(param0: java.lang.Long): void;
+				public getStacktrace(): io.sentry.protocol.SentryStackTrace;
+				public setMechanism(param0: io.sentry.protocol.Mechanism): void;
+				public getThreadId(): java.lang.Long;
+				public setStacktrace(param0: io.sentry.protocol.SentryStackTrace): void;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class SentryId {
+				public static class: java.lang.Class<io.sentry.protocol.SentryId>;
+				public static EMPTY_ID: io.sentry.protocol.SentryId;
+				public hashCode(): number;
+				public constructor(param0: java.util.UUID);
+				public equals(param0: any): boolean;
 				public toString(): string;
+				public constructor(param0: string);
 				public constructor();
 			}
 		}
@@ -37,2217 +3864,524 @@ declare module com {
 }
 
 declare module io {
-  export module sentry {
-    export module core {
-      export class AsyncConnectionFactory {
-        public static class: java.lang.Class<io.sentry.core.AsyncConnectionFactory>;
-        public static create(param0: io.sentry.core.SentryOptions, param1: io.sentry.core.cache.IEventCache): io.sentry.core.transport.AsyncConnection;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class Breadcrumb extends io.sentry.core.IUnknownPropertiesConsumer {
-        public static class: java.lang.Class<io.sentry.core.Breadcrumb>;
-        public getTimestamp(): java.util.Date;
-        public getType(): string;
-        public setData(param0: string, param1: any): void;
-        public setCategory(param0: string): void;
-        public setType(param0: string): void;
-        public constructor(param0: string);
-        public setLevel(param0: io.sentry.core.SentryLevel): void;
-        public constructor();
-        public getCategory(): string;
-        public getLevel(): io.sentry.core.SentryLevel;
-        public clone(): io.sentry.core.Breadcrumb;
-        public setMessage(param0: string): void;
-        public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-        public getMessage(): string;
-        public removeData(param0: string): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class CircularFifoQueue<E>  extends java.util.AbstractCollection<any> {
-        public static class: java.lang.Class<io.sentry.core.CircularFifoQueue<any>>;
-        public remove(): any;
-        public element(): any;
-        public peek(): any;
-        public iterator(): java.util.Iterator<any>;
-        public get(param0: number): any;
-        public constructor();
-        public size(): number;
-        public poll(): any;
-        public constructor(param0: java.util.Collection<any>);
-        public maxSize(): number;
-        public add(param0: any): boolean;
-        public offer(param0: any): boolean;
-        public clear(): void;
-        public isFull(): boolean;
-        public isAtFullCapacity(): boolean;
-        public isEmpty(): boolean;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class CredentialsSettingConfigurator extends io.sentry.core.transport.IConnectionConfigurator {
-        public static class: java.lang.Class<io.sentry.core.CredentialsSettingConfigurator>;
-        public configure(param0: java.net.HttpURLConnection): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class DateUtils {
-        public static class: java.lang.Class<io.sentry.core.DateUtils>;
-        public static getCurrentDateTime(): java.util.Date;
-        public static getDateTime(param0: string): java.util.Date;
-        public static getDateTimeWithMillsPrecision(param0: string): java.util.Date;
-        public static getTimestamp(param0: java.util.Date): string;
-        public static getTimestampIsoFormat(param0: java.util.Date): string;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class DiagnosticLogger extends io.sentry.core.ILogger {
-        public static class: java.lang.Class<io.sentry.core.DiagnosticLogger>;
-        public log(param0: io.sentry.core.SentryLevel, param1: string, param2: native.Array<any>): void;
-        public constructor(param0: io.sentry.core.SentryOptions, param1: io.sentry.core.ILogger);
-        public getLogger(): io.sentry.core.ILogger;
-        public isEnabled(param0: io.sentry.core.SentryLevel): boolean;
-        public log(param0: io.sentry.core.SentryLevel, param1: string, param2: java.lang.Throwable): void;
-        public log(param0: io.sentry.core.SentryLevel, param1: java.lang.Throwable, param2: string, param3: native.Array<any>): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export abstract class DirectoryProcessor {
-        public static class: java.lang.Class<io.sentry.core.DirectoryProcessor>;
-        public isRelevantFileName(param0: string): boolean;
-        public processFile(param0: java.io.File): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class Dsn {
-        public static class: java.lang.Class<io.sentry.core.Dsn>;
-        public getPublicKey(): string;
-        public getPath(): string;
-        public getProjectId(): string;
-        public getSecretKey(): string;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class EnvelopeReader extends io.sentry.core.IEnvelopeReader {
-        public static class: java.lang.Class<io.sentry.core.EnvelopeReader>;
-        public read(param0: java.io.InputStream): io.sentry.core.SentryEnvelope;
-        public constructor();
-      }
-      export module EnvelopeReader {
-        export class SentryEnvelopeHeaderAdapter extends com.google.gson.TypeAdapter<io.sentry.core.SentryEnvelopeHeader> {
-          public static class: java.lang.Class<io.sentry.core.EnvelopeReader.SentryEnvelopeHeaderAdapter>;
-          public write(param0: any, param1: io.sentry.core.SentryEnvelopeHeader): void;
-          public read(param0: any): io.sentry.core.SentryEnvelopeHeader;
-        }
-        export class SentryEnvelopeItemHeaderAdapter extends com.google.gson.TypeAdapter<io.sentry.core.SentryEnvelopeItemHeader> {
-          public static class: java.lang.Class<io.sentry.core.EnvelopeReader.SentryEnvelopeItemHeaderAdapter>;
-          public write(param0: any, param1: io.sentry.core.SentryEnvelopeItemHeader): void;
-          public read(param0: any): io.sentry.core.SentryEnvelopeItemHeader;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class EnvelopeSender extends io.sentry.core.DirectoryProcessor implements io.sentry.core.IEnvelopeSender {
-        public static class: java.lang.Class<io.sentry.core.EnvelopeSender>;
-        public processEnvelopeFile(param0: string): void;
-        public constructor(param0: io.sentry.core.IHub, param1: io.sentry.core.IEnvelopeReader, param2: io.sentry.core.ISerializer, param3: io.sentry.core.ILogger);
-        public isRelevantFileName(param0: string): boolean;
-        public processFile(param0: java.io.File): void;
-      }
-      export module EnvelopeSender {
-        export class CachedEnvelopeHint implements io.sentry.core.hints.Cached, io.sentry.core.hints.Retryable, io.sentry.core.hints.SubmissionResult {
-          public static class: java.lang.Class<io.sentry.core.EnvelopeSender.CachedEnvelopeHint>;
-          public reset(): void;
-          public setRetry(param0: boolean): void;
-          public getRetry(): boolean;
-          public setResult(param0: boolean): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class EventProcessor {
-        public static class: java.lang.Class<io.sentry.core.EventProcessor>;
-        /**
-         * Constructs a new instance of the io.sentry.core.EventProcessor interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-         */
-        public constructor(implementation: {
-          process(param0: io.sentry.core.SentryEvent, param1: any): io.sentry.core.SentryEvent;
-        });
-        public constructor();
-        public process(param0: io.sentry.core.SentryEvent, param1: any): io.sentry.core.SentryEvent;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class HttpTransportFactory {
-        public static class: java.lang.Class<io.sentry.core.HttpTransportFactory>;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class Hub extends io.sentry.core.IHub {
-        public static class: java.lang.Class<io.sentry.core.Hub>;
-        public constructor(param0: io.sentry.core.SentryOptions);
-        public popScope(): void;
-        public bindClient(param0: io.sentry.core.ISentryClient): void;
-        public removeExtra(param0: string): void;
-        public setFingerprint(param0: java.util.List<string>): void;
-        public captureEvent(param0: io.sentry.core.SentryEvent): io.sentry.core.protocol.SentryId;
-        public setUser(param0: io.sentry.core.protocol.User): void;
-        public setExtra(param0: string, param1: string): void;
-        public removeTag(param0: string): void;
-        public withScope(param0: io.sentry.core.ScopeCallback): void;
-        public addBreadcrumb(param0: string): void;
-        public setTag(param0: string, param1: string): void;
-        public addBreadcrumb(param0: string, param1: string): void;
-        public captureMessage(param0: string): io.sentry.core.protocol.SentryId;
-        public captureException(param0: java.lang.Throwable): io.sentry.core.protocol.SentryId;
-        public close(): void;
-        public pushScope(): void;
-        public clearBreadcrumbs(): void;
-        public getLastEventId(): io.sentry.core.protocol.SentryId;
-        public configureScope(param0: io.sentry.core.ScopeCallback): void;
-        public setLevel(param0: io.sentry.core.SentryLevel): void;
-        public setTransaction(param0: string): void;
-        public addBreadcrumb(param0: io.sentry.core.Breadcrumb, param1: any): void;
-        public captureEvent(param0: io.sentry.core.SentryEvent, param1: any): io.sentry.core.protocol.SentryId;
-        public isEnabled(): boolean;
-        public captureMessage(param0: string, param1: io.sentry.core.SentryLevel): io.sentry.core.protocol.SentryId;
-        public addBreadcrumb(param0: io.sentry.core.Breadcrumb): void;
-        public clone(): io.sentry.core.IHub;
-        public captureException(param0: java.lang.Throwable, param1: any): io.sentry.core.protocol.SentryId;
-        public flush(param0: number): void;
-      }
-      export module Hub {
-        export class StackItem {
-          public static class: java.lang.Class<io.sentry.core.Hub.StackItem>;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class HubAdapter extends io.sentry.core.IHub {
-        public static class: java.lang.Class<io.sentry.core.HubAdapter>;
-        public popScope(): void;
-        public bindClient(param0: io.sentry.core.ISentryClient): void;
-        public removeExtra(param0: string): void;
-        public setFingerprint(param0: java.util.List<string>): void;
-        public captureEvent(param0: io.sentry.core.SentryEvent): io.sentry.core.protocol.SentryId;
-        public setUser(param0: io.sentry.core.protocol.User): void;
-        public setExtra(param0: string, param1: string): void;
-        public removeTag(param0: string): void;
-        public withScope(param0: io.sentry.core.ScopeCallback): void;
-        public addBreadcrumb(param0: string): void;
-        public setTag(param0: string, param1: string): void;
-        public addBreadcrumb(param0: string, param1: string): void;
-        public captureMessage(param0: string): io.sentry.core.protocol.SentryId;
-        public captureException(param0: java.lang.Throwable): io.sentry.core.protocol.SentryId;
-        public close(): void;
-        public pushScope(): void;
-        public clearBreadcrumbs(): void;
-        public getLastEventId(): io.sentry.core.protocol.SentryId;
-        public configureScope(param0: io.sentry.core.ScopeCallback): void;
-        public setLevel(param0: io.sentry.core.SentryLevel): void;
-        public setTransaction(param0: string): void;
-        public static getInstance(): io.sentry.core.HubAdapter;
-        public addBreadcrumb(param0: io.sentry.core.Breadcrumb, param1: any): void;
-        public captureEvent(param0: io.sentry.core.SentryEvent, param1: any): io.sentry.core.protocol.SentryId;
-        public isEnabled(): boolean;
-        public captureMessage(param0: string, param1: io.sentry.core.SentryLevel): io.sentry.core.protocol.SentryId;
-        public addBreadcrumb(param0: io.sentry.core.Breadcrumb): void;
-        public clone(): io.sentry.core.IHub;
-        public captureException(param0: java.lang.Throwable, param1: any): io.sentry.core.protocol.SentryId;
-        public flush(param0: number): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class IEnvelopeReader {
-        public static class: java.lang.Class<io.sentry.core.IEnvelopeReader>;
-        /**
-         * Constructs a new instance of the io.sentry.core.IEnvelopeReader interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-         */
-        public constructor(implementation: {
-          read(param0: java.io.InputStream): io.sentry.core.SentryEnvelope;
-        });
-        public constructor();
-        public read(param0: java.io.InputStream): io.sentry.core.SentryEnvelope;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class IEnvelopeSender {
-        public static class: java.lang.Class<io.sentry.core.IEnvelopeSender>;
-        /**
-         * Constructs a new instance of the io.sentry.core.IEnvelopeSender interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-         */
-        public constructor(implementation: {
-          processEnvelopeFile(param0: string): void;
-        });
-        public constructor();
-        public processEnvelopeFile(param0: string): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class IHub {
-        public static class: java.lang.Class<io.sentry.core.IHub>;
-        /**
-         * Constructs a new instance of the io.sentry.core.IHub interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-         */
-        public constructor(implementation: {
-          isEnabled(): boolean;
-          captureEvent(param0: io.sentry.core.SentryEvent, param1: any): io.sentry.core.protocol.SentryId;
-          captureEvent(param0: io.sentry.core.SentryEvent): io.sentry.core.protocol.SentryId;
-          captureMessage(param0: string): io.sentry.core.protocol.SentryId;
-          captureMessage(param0: string, param1: io.sentry.core.SentryLevel): io.sentry.core.protocol.SentryId;
-          captureException(param0: java.lang.Throwable, param1: any): io.sentry.core.protocol.SentryId;
-          captureException(param0: java.lang.Throwable): io.sentry.core.protocol.SentryId;
-          close(): void;
-          addBreadcrumb(param0: io.sentry.core.Breadcrumb, param1: any): void;
-          addBreadcrumb(param0: io.sentry.core.Breadcrumb): void;
-          addBreadcrumb(param0: string): void;
-          addBreadcrumb(param0: string, param1: string): void;
-          setLevel(param0: io.sentry.core.SentryLevel): void;
-          setTransaction(param0: string): void;
-          setUser(param0: io.sentry.core.protocol.User): void;
-          setFingerprint(param0: java.util.List<string>): void;
-          clearBreadcrumbs(): void;
-          setTag(param0: string, param1: string): void;
-          removeTag(param0: string): void;
-          setExtra(param0: string, param1: string): void;
-          removeExtra(param0: string): void;
-          getLastEventId(): io.sentry.core.protocol.SentryId;
-          pushScope(): void;
-          popScope(): void;
-          withScope(param0: io.sentry.core.ScopeCallback): void;
-          configureScope(param0: io.sentry.core.ScopeCallback): void;
-          bindClient(param0: io.sentry.core.ISentryClient): void;
-          flush(param0: number): void;
-          clone(): io.sentry.core.IHub;
-        });
-        public constructor();
-        public popScope(): void;
-        public bindClient(param0: io.sentry.core.ISentryClient): void;
-        public removeExtra(param0: string): void;
-        public setFingerprint(param0: java.util.List<string>): void;
-        public captureEvent(param0: io.sentry.core.SentryEvent): io.sentry.core.protocol.SentryId;
-        public setUser(param0: io.sentry.core.protocol.User): void;
-        public setExtra(param0: string, param1: string): void;
-        public removeTag(param0: string): void;
-        public withScope(param0: io.sentry.core.ScopeCallback): void;
-        public addBreadcrumb(param0: string): void;
-        public setTag(param0: string, param1: string): void;
-        public addBreadcrumb(param0: string, param1: string): void;
-        public captureMessage(param0: string): io.sentry.core.protocol.SentryId;
-        public captureException(param0: java.lang.Throwable): io.sentry.core.protocol.SentryId;
-        public close(): void;
-        public pushScope(): void;
-        public clearBreadcrumbs(): void;
-        public getLastEventId(): io.sentry.core.protocol.SentryId;
-        public configureScope(param0: io.sentry.core.ScopeCallback): void;
-        public setLevel(param0: io.sentry.core.SentryLevel): void;
-        public setTransaction(param0: string): void;
-        public addBreadcrumb(param0: io.sentry.core.Breadcrumb, param1: any): void;
-        public captureEvent(param0: io.sentry.core.SentryEvent, param1: any): io.sentry.core.protocol.SentryId;
-        public isEnabled(): boolean;
-        public captureMessage(param0: string, param1: io.sentry.core.SentryLevel): io.sentry.core.protocol.SentryId;
-        public addBreadcrumb(param0: io.sentry.core.Breadcrumb): void;
-        public clone(): io.sentry.core.IHub;
-        public captureException(param0: java.lang.Throwable, param1: any): io.sentry.core.protocol.SentryId;
-        public flush(param0: number): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class ILogger {
-        public static class: java.lang.Class<io.sentry.core.ILogger>;
-        /**
-         * Constructs a new instance of the io.sentry.core.ILogger interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-         */
-        public constructor(implementation: {
-          log(param0: io.sentry.core.SentryLevel, param1: string, param2: native.Array<any>): void;
-          log(param0: io.sentry.core.SentryLevel, param1: string, param2: java.lang.Throwable): void;
-          log(param0: io.sentry.core.SentryLevel, param1: java.lang.Throwable, param2: string, param3: native.Array<any>): void;
-        });
-        public constructor();
-        public log(param0: io.sentry.core.SentryLevel, param1: string, param2: native.Array<any>): void;
-        public log(param0: io.sentry.core.SentryLevel, param1: string, param2: java.lang.Throwable): void;
-        public log(param0: io.sentry.core.SentryLevel, param1: java.lang.Throwable, param2: string, param3: native.Array<any>): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class ISentryClient {
-        public static class: java.lang.Class<io.sentry.core.ISentryClient>;
-        /**
-         * Constructs a new instance of the io.sentry.core.ISentryClient interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-         */
-        public constructor(implementation: {
-          isEnabled(): boolean;
-          captureEvent(param0: io.sentry.core.SentryEvent, param1: io.sentry.core.Scope, param2: any): io.sentry.core.protocol.SentryId;
-          close(): void;
-          flush(param0: number): void;
-          captureEvent(param0: io.sentry.core.SentryEvent): io.sentry.core.protocol.SentryId;
-          captureEvent(param0: io.sentry.core.SentryEvent, param1: io.sentry.core.Scope): io.sentry.core.protocol.SentryId;
-          captureEvent(param0: io.sentry.core.SentryEvent, param1: any): io.sentry.core.protocol.SentryId;
-          captureMessage(param0: string, param1: io.sentry.core.SentryLevel, param2: io.sentry.core.Scope): io.sentry.core.protocol.SentryId;
-          captureMessage(param0: string, param1: io.sentry.core.SentryLevel): io.sentry.core.protocol.SentryId;
-          captureException(param0: java.lang.Throwable): io.sentry.core.protocol.SentryId;
-          captureException(param0: java.lang.Throwable, param1: io.sentry.core.Scope, param2: any): io.sentry.core.protocol.SentryId;
-          captureException(param0: java.lang.Throwable, param1: any): io.sentry.core.protocol.SentryId;
-          captureException(param0: java.lang.Throwable, param1: io.sentry.core.Scope): io.sentry.core.protocol.SentryId;
-        });
-        public constructor();
-        public captureException(param0: java.lang.Throwable): io.sentry.core.protocol.SentryId;
-        public close(): void;
-        public captureEvent(param0: io.sentry.core.SentryEvent, param1: io.sentry.core.Scope, param2: any): io.sentry.core.protocol.SentryId;
-        public captureEvent(param0: io.sentry.core.SentryEvent): io.sentry.core.protocol.SentryId;
-        public captureEvent(param0: io.sentry.core.SentryEvent, param1: io.sentry.core.Scope): io.sentry.core.protocol.SentryId;
-        public captureException(param0: java.lang.Throwable, param1: io.sentry.core.Scope, param2: any): io.sentry.core.protocol.SentryId;
-        public captureMessage(param0: string, param1: io.sentry.core.SentryLevel, param2: io.sentry.core.Scope): io.sentry.core.protocol.SentryId;
-        public captureException(param0: java.lang.Throwable, param1: io.sentry.core.Scope): io.sentry.core.protocol.SentryId;
-        public captureEvent(param0: io.sentry.core.SentryEvent, param1: any): io.sentry.core.protocol.SentryId;
-        public isEnabled(): boolean;
-        public captureMessage(param0: string, param1: io.sentry.core.SentryLevel): io.sentry.core.protocol.SentryId;
-        public flush(param0: number): void;
-        public captureException(param0: java.lang.Throwable, param1: any): io.sentry.core.protocol.SentryId;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class ISerializer {
-        public static class: java.lang.Class<io.sentry.core.ISerializer>;
-        /**
-         * Constructs a new instance of the io.sentry.core.ISerializer interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-         */
-        public constructor(implementation: {
-          deserializeEvent(param0: java.io.Reader): io.sentry.core.SentryEvent;
-          serialize(param0: io.sentry.core.SentryEvent, param1: java.io.Writer): void;
-        });
-        public constructor();
-        public deserializeEvent(param0: java.io.Reader): io.sentry.core.SentryEvent;
-        public serialize(param0: io.sentry.core.SentryEvent, param1: java.io.Writer): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class IUnknownPropertiesConsumer {
-        public static class: java.lang.Class<io.sentry.core.IUnknownPropertiesConsumer>;
-        /**
-         * Constructs a new instance of the io.sentry.core.IUnknownPropertiesConsumer interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-         */
-        public constructor(implementation: {
-          acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-        });
-        public constructor();
-        public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class Integration {
-        public static class: java.lang.Class<io.sentry.core.Integration>;
-        /**
-         * Constructs a new instance of the io.sentry.core.Integration interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-         */
-        public constructor(implementation: {
-          register(param0: io.sentry.core.IHub, param1: io.sentry.core.SentryOptions): void;
-        });
-        public constructor();
-        public register(param0: io.sentry.core.IHub, param1: io.sentry.core.SentryOptions): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class InvalidDsnException {
-        public static class: java.lang.Class<io.sentry.core.InvalidDsnException>;
-        public getDsn(): string;
-        public constructor(param0: string);
-        public constructor(param0: string, param1: string);
-        public constructor(param0: string, param1: string, param2: java.lang.Throwable);
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class MainEventProcessor extends io.sentry.core.EventProcessor {
-        public static class: java.lang.Class<io.sentry.core.MainEventProcessor>;
-        public process(param0: io.sentry.core.SentryEvent, param1: any): io.sentry.core.SentryEvent;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class NoOpHub extends io.sentry.core.IHub {
-        public static class: java.lang.Class<io.sentry.core.NoOpHub>;
-        public popScope(): void;
-        public bindClient(param0: io.sentry.core.ISentryClient): void;
-        public removeExtra(param0: string): void;
-        public setFingerprint(param0: java.util.List<string>): void;
-        public captureEvent(param0: io.sentry.core.SentryEvent): io.sentry.core.protocol.SentryId;
-        public setUser(param0: io.sentry.core.protocol.User): void;
-        public setExtra(param0: string, param1: string): void;
-        public removeTag(param0: string): void;
-        public withScope(param0: io.sentry.core.ScopeCallback): void;
-        public addBreadcrumb(param0: string): void;
-        public setTag(param0: string, param1: string): void;
-        public addBreadcrumb(param0: string, param1: string): void;
-        public captureMessage(param0: string): io.sentry.core.protocol.SentryId;
-        public captureException(param0: java.lang.Throwable): io.sentry.core.protocol.SentryId;
-        public close(): void;
-        public pushScope(): void;
-        public clearBreadcrumbs(): void;
-        public getLastEventId(): io.sentry.core.protocol.SentryId;
-        public configureScope(param0: io.sentry.core.ScopeCallback): void;
-        public setLevel(param0: io.sentry.core.SentryLevel): void;
-        public setTransaction(param0: string): void;
-        public addBreadcrumb(param0: io.sentry.core.Breadcrumb, param1: any): void;
-        public captureEvent(param0: io.sentry.core.SentryEvent, param1: any): io.sentry.core.protocol.SentryId;
-        public static getInstance(): io.sentry.core.NoOpHub;
-        public isEnabled(): boolean;
-        public captureMessage(param0: string, param1: io.sentry.core.SentryLevel): io.sentry.core.protocol.SentryId;
-        public addBreadcrumb(param0: io.sentry.core.Breadcrumb): void;
-        public clone(): io.sentry.core.IHub;
-        public captureException(param0: java.lang.Throwable, param1: any): io.sentry.core.protocol.SentryId;
-        public flush(param0: number): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class NoOpLogger extends io.sentry.core.ILogger {
-        public static class: java.lang.Class<io.sentry.core.NoOpLogger>;
-        public log(param0: io.sentry.core.SentryLevel, param1: string, param2: native.Array<any>): void;
-        public static getInstance(): io.sentry.core.NoOpLogger;
-        public log(param0: io.sentry.core.SentryLevel, param1: string, param2: java.lang.Throwable): void;
-        public log(param0: io.sentry.core.SentryLevel, param1: java.lang.Throwable, param2: string, param3: native.Array<any>): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class NoOpSentryClient extends io.sentry.core.ISentryClient {
-        public static class: java.lang.Class<io.sentry.core.NoOpSentryClient>;
-        public captureException(param0: java.lang.Throwable): io.sentry.core.protocol.SentryId;
-        public close(): void;
-        public captureEvent(param0: io.sentry.core.SentryEvent, param1: io.sentry.core.Scope, param2: any): io.sentry.core.protocol.SentryId;
-        public captureEvent(param0: io.sentry.core.SentryEvent): io.sentry.core.protocol.SentryId;
-        public captureEvent(param0: io.sentry.core.SentryEvent, param1: io.sentry.core.Scope): io.sentry.core.protocol.SentryId;
-        public static getInstance(): io.sentry.core.NoOpSentryClient;
-        public captureException(param0: java.lang.Throwable, param1: io.sentry.core.Scope, param2: any): io.sentry.core.protocol.SentryId;
-        public captureMessage(param0: string, param1: io.sentry.core.SentryLevel, param2: io.sentry.core.Scope): io.sentry.core.protocol.SentryId;
-        public captureException(param0: java.lang.Throwable, param1: io.sentry.core.Scope): io.sentry.core.protocol.SentryId;
-        public captureEvent(param0: io.sentry.core.SentryEvent, param1: any): io.sentry.core.protocol.SentryId;
-        public isEnabled(): boolean;
-        public captureMessage(param0: string, param1: io.sentry.core.SentryLevel): io.sentry.core.protocol.SentryId;
-        public flush(param0: number): void;
-        public captureException(param0: java.lang.Throwable, param1: any): io.sentry.core.protocol.SentryId;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class NoOpSerializer extends io.sentry.core.ISerializer {
-        public static class: java.lang.Class<io.sentry.core.NoOpSerializer>;
-        public static getInstance(): io.sentry.core.NoOpSerializer;
-        public deserializeEvent(param0: java.io.Reader): io.sentry.core.SentryEvent;
-        public serialize(param0: io.sentry.core.SentryEvent, param1: java.io.Writer): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class OptionsContainer<T>  extends java.lang.Object {
-        public static class: java.lang.Class<io.sentry.core.OptionsContainer<any>>;
-        public createInstance(): T;
-        public static create(param0: java.lang.Class<any>): io.sentry.core.OptionsContainer<any>;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class Scope {
-        public static class: java.lang.Class<io.sentry.core.Scope>;
-        public constructor(param0: io.sentry.core.SentryOptions);
-        public removeExtra(param0: string): void;
-        public setFingerprint(param0: java.util.List<string>): void;
-        public clearBreadcrumbs(): void;
-        public clone(): io.sentry.core.Scope;
-        public setUser(param0: io.sentry.core.protocol.User): void;
-        public setLevel(param0: io.sentry.core.SentryLevel): void;
-        public setTransaction(param0: string): void;
-        public setExtra(param0: string, param1: string): void;
-        public getLevel(): io.sentry.core.SentryLevel;
-        public addBreadcrumb(param0: io.sentry.core.Breadcrumb, param1: any): void;
-        public removeTag(param0: string): void;
-        public clear(): void;
-        public getTransaction(): string;
-        public getUser(): io.sentry.core.protocol.User;
-        public addBreadcrumb(param0: io.sentry.core.Breadcrumb): void;
-        public addEventProcessor(param0: io.sentry.core.EventProcessor): void;
-        public setTag(param0: string, param1: string): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class ScopeCallback {
-        public static class: java.lang.Class<io.sentry.core.ScopeCallback>;
-        /**
-         * Constructs a new instance of the io.sentry.core.ScopeCallback interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-         */
-        public constructor(implementation: {
-          run(param0: io.sentry.core.Scope): void;
-        });
-        public constructor();
-        public run(param0: io.sentry.core.Scope): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SendCachedEvent extends io.sentry.core.DirectoryProcessor {
-        public static class: java.lang.Class<io.sentry.core.SendCachedEvent>;
-        public isRelevantFileName(param0: string): boolean;
-        public processFile(param0: java.io.File): void;
-      }
-      export module SendCachedEvent {
-        export class SendCachedEventHint implements io.sentry.core.hints.Cached, io.sentry.core.hints.Retryable, io.sentry.core.hints.SubmissionResult {
-          public static class: java.lang.Class<io.sentry.core.SendCachedEvent.SendCachedEventHint>;
-          public setRetry(param0: boolean): void;
-          public getRetry(): boolean;
-          public setResult(param0: boolean): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SendCachedEventFireAndForgetIntegration extends io.sentry.core.Integration {
-        public static class: java.lang.Class<io.sentry.core.SendCachedEventFireAndForgetIntegration>;
-        public register(param0: io.sentry.core.IHub, param1: io.sentry.core.SentryOptions): void;
-      }
-      export module SendCachedEventFireAndForgetIntegration {
-        export class SendFireAndForget {
-          public static class: java.lang.Class<io.sentry.core.SendCachedEventFireAndForgetIntegration.SendFireAndForget>;
-          /**
-           * Constructs a new instance of the io.sentry.core.SendCachedEventFireAndForgetIntegration$SendFireAndForget interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-           */
-          public constructor(implementation: {
-            send(): void;
-          });
-          public constructor();
-          public send(): void;
-        }
-        export class SendFireAndForgetFactory {
-          public static class: java.lang.Class<io.sentry.core.SendCachedEventFireAndForgetIntegration.SendFireAndForgetFactory>;
-          /**
-           * Constructs a new instance of the io.sentry.core.SendCachedEventFireAndForgetIntegration$SendFireAndForgetFactory interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-           */
-          public constructor(implementation: {
-            create(param0: io.sentry.core.IHub, param1: io.sentry.core.SentryOptions): io.sentry.core.SendCachedEventFireAndForgetIntegration.SendFireAndForget;
-          });
-          public constructor();
-          public create(param0: io.sentry.core.IHub, param1: io.sentry.core.SentryOptions): io.sentry.core.SendCachedEventFireAndForgetIntegration.SendFireAndForget;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class Sentry {
-        public static class: java.lang.Class<io.sentry.core.Sentry>;
-        public static init(): void;
-        public static addBreadcrumb(param0: io.sentry.core.Breadcrumb): void;
-        public static init(param0: io.sentry.core.OptionsContainer<any>, param1: io.sentry.core.Sentry.OptionsConfiguration<any>, param2: boolean): void;
-        public static clearBreadcrumbs(): void;
-        public static captureException(param0: java.lang.Throwable, param1: any): io.sentry.core.protocol.SentryId;
-        public static addBreadcrumb(param0: string, param1: string): void;
-        public static init(param0: io.sentry.core.OptionsContainer<any>, param1: io.sentry.core.Sentry.OptionsConfiguration<any>): void;
-        public static setTransaction(param0: string): void;
-        public static popScope(): void;
-        public static addBreadcrumb(param0: io.sentry.core.Breadcrumb, param1: any): void;
-        public static captureEvent(param0: io.sentry.core.SentryEvent): io.sentry.core.protocol.SentryId;
-        public static setLevel(param0: io.sentry.core.SentryLevel): void;
-        public static setExtra(param0: string, param1: string): void;
-        public static getLastEventId(): io.sentry.core.protocol.SentryId;
-        public static bindClient(param0: io.sentry.core.ISentryClient): void;
-        public static withScope(param0: io.sentry.core.ScopeCallback): void;
-        public static configureScope(param0: io.sentry.core.ScopeCallback): void;
-        public static removeExtra(param0: string): void;
-        public static init(param0: io.sentry.core.Sentry.OptionsConfiguration<io.sentry.core.SentryOptions>, param1: boolean): void;
-        public static flush(param0: number): void;
-        public static setFingerprint(param0: java.util.List<string>): void;
-        public static init(param0: io.sentry.core.Sentry.OptionsConfiguration<io.sentry.core.SentryOptions>): void;
-        public static captureEvent(param0: io.sentry.core.SentryEvent, param1: any): io.sentry.core.protocol.SentryId;
-        public static captureMessage(param0: string, param1: io.sentry.core.SentryLevel): io.sentry.core.protocol.SentryId;
-        public static isEnabled(): boolean;
-        public static removeTag(param0: string): void;
-        public static close(): void;
-        public static captureMessage(param0: string): io.sentry.core.protocol.SentryId;
-        public static setTag(param0: string, param1: string): void;
-        public static addBreadcrumb(param0: string): void;
-        public static pushScope(): void;
-        public static captureException(param0: java.lang.Throwable): io.sentry.core.protocol.SentryId;
-        public static setUser(param0: io.sentry.core.protocol.User): void;
-      }
-      export module Sentry {
-        export class OptionsConfiguration<T>  extends java.lang.Object {
-          public static class: java.lang.Class<io.sentry.core.Sentry.OptionsConfiguration<any>>;
-          /**
-           * Constructs a new instance of the io.sentry.core.Sentry$OptionsConfiguration interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-           */
-          public constructor(implementation: {
-            configure(param0: T): void;
-          });
-          public constructor();
-          public configure(param0: T): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SentryClient extends io.sentry.core.ISentryClient {
-        public static class: java.lang.Class<io.sentry.core.SentryClient>;
-        public captureException(param0: java.lang.Throwable): io.sentry.core.protocol.SentryId;
-        public close(): void;
-        public captureEvent(param0: io.sentry.core.SentryEvent, param1: io.sentry.core.Scope, param2: any): io.sentry.core.protocol.SentryId;
-        public captureEvent(param0: io.sentry.core.SentryEvent): io.sentry.core.protocol.SentryId;
-        public captureEvent(param0: io.sentry.core.SentryEvent, param1: io.sentry.core.Scope): io.sentry.core.protocol.SentryId;
-        public captureException(param0: java.lang.Throwable, param1: io.sentry.core.Scope, param2: any): io.sentry.core.protocol.SentryId;
-        public captureMessage(param0: string, param1: io.sentry.core.SentryLevel, param2: io.sentry.core.Scope): io.sentry.core.protocol.SentryId;
-        public captureException(param0: java.lang.Throwable, param1: io.sentry.core.Scope): io.sentry.core.protocol.SentryId;
-        public captureEvent(param0: io.sentry.core.SentryEvent, param1: any): io.sentry.core.protocol.SentryId;
-        public constructor(param0: io.sentry.core.SentryOptions, param1: io.sentry.core.transport.Connection);
-        public isEnabled(): boolean;
-        public captureMessage(param0: string, param1: io.sentry.core.SentryLevel): io.sentry.core.protocol.SentryId;
-        public flush(param0: number): void;
-        public captureException(param0: java.lang.Throwable, param1: any): io.sentry.core.protocol.SentryId;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SentryEnvelope {
-        public static class: java.lang.Class<io.sentry.core.SentryEnvelope>;
-        public constructor(param0: io.sentry.core.protocol.SentryId, param1: string, param2: java.lang.Iterable<io.sentry.core.SentryEnvelopeItem>);
-        public getItems(): java.lang.Iterable<io.sentry.core.SentryEnvelopeItem>;
-        public getHeader(): io.sentry.core.SentryEnvelopeHeader;
-        public constructor(param0: io.sentry.core.protocol.SentryId, param1: java.lang.Iterable<io.sentry.core.SentryEnvelopeItem>);
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SentryEnvelopeHeader {
-        public static class: java.lang.Class<io.sentry.core.SentryEnvelopeHeader>;
-        public getAuth(): string;
-        public getEventId(): io.sentry.core.protocol.SentryId;
-        public constructor(param0: io.sentry.core.protocol.SentryId);
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SentryEnvelopeItem {
-        public static class: java.lang.Class<io.sentry.core.SentryEnvelopeItem>;
-        public getData(): native.Array<number>;
-        public getHeader(): io.sentry.core.SentryEnvelopeItemHeader;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SentryEnvelopeItemHeader {
-        public static class: java.lang.Class<io.sentry.core.SentryEnvelopeItemHeader>;
-        public getType(): string;
-        public getContentType(): string;
-        public getFileName(): string;
-        public getLength(): number;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SentryEvent extends io.sentry.core.IUnknownPropertiesConsumer {
-        public static class: java.lang.Class<io.sentry.core.SentryEvent>;
-        public setExceptions(param0: java.util.List<io.sentry.core.protocol.SentryException>): void;
-        public getSdk(): io.sentry.core.protocol.SdkVersion;
-        public setEventId(param0: io.sentry.core.protocol.SentryId): void;
-        public setBreadcrumbs(param0: java.util.List<io.sentry.core.Breadcrumb>): void;
-        public setServerName(param0: string): void;
-        public setSdk(param0: io.sentry.core.protocol.SdkVersion): void;
-        public constructor(param0: java.lang.Throwable);
-        public constructor();
-        public getBreadcrumbs(): java.util.List<io.sentry.core.Breadcrumb>;
-        public setMessage(param0: io.sentry.core.protocol.Message): void;
-        public getEnvironment(): string;
-        public getLevel(): io.sentry.core.SentryLevel;
-        public getExceptions(): java.util.List<io.sentry.core.protocol.SentryException>;
-        public setContexts(param0: io.sentry.core.protocol.Contexts): void;
-        public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-        public getRelease(): string;
-        public setRelease(param0: string): void;
-        public setTag(param0: string, param1: string): void;
-        public getTimestamp(): java.util.Date;
-        public removeModule(param0: string): void;
-        public getLogger(): string;
-        public constructor(param0: java.util.Date);
-        public getUnknown(): java.util.Map<string,any>;
-        public setLevel(param0: io.sentry.core.SentryLevel): void;
-        public getEventId(): io.sentry.core.protocol.SentryId;
-        public setFingerprints(param0: java.util.List<string>): void;
-        public getContexts(): io.sentry.core.protocol.Contexts;
-        public setEnvironment(param0: string): void;
-        public getUser(): io.sentry.core.protocol.User;
-        public addBreadcrumb(param0: io.sentry.core.Breadcrumb): void;
-        public setExtras(param0: java.util.Map<string,any>): void;
-        public getServerName(): string;
-        public removeExtra(param0: string): void;
-        public getRequest(): io.sentry.core.protocol.Request;
-        public setThrowable(param0: java.lang.Throwable): void;
-        public setModule(param0: string, param1: string): void;
-        public setUser(param0: io.sentry.core.protocol.User): void;
-        public setTags(param0: java.util.Map<string,string>): void;
-        public getMessage(): io.sentry.core.protocol.Message;
-        public removeTag(param0: string): void;
-        public getDist(): string;
-        public setPlatform(param0: string): void;
-        public setExtra(param0: string, param1: any): void;
-        public setLogger(param0: string): void;
-        public getTransaction(): string;
-        public getDebugMeta(): io.sentry.core.protocol.DebugMeta;
-        public setRequest(param0: io.sentry.core.protocol.Request): void;
-        public setThreads(param0: java.util.List<io.sentry.core.protocol.SentryThread>): void;
-        public getThreads(): java.util.List<io.sentry.core.protocol.SentryThread>;
-        public setTransaction(param0: string): void;
-        public setDebugMeta(param0: io.sentry.core.protocol.DebugMeta): void;
-        public getPlatform(): string;
-        public setModules(param0: java.util.Map<string,string>): void;
-        public setDist(param0: string): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SentryExceptionFactory {
-        public static class: java.lang.Class<io.sentry.core.SentryExceptionFactory>;
-        public constructor(param0: io.sentry.core.SentryStackTraceFactory);
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SentryLevel {
-        public static class: java.lang.Class<io.sentry.core.SentryLevel>;
-        public static LOG: io.sentry.core.SentryLevel;
-        public static DEBUG: io.sentry.core.SentryLevel;
-        public static INFO: io.sentry.core.SentryLevel;
-        public static WARNING: io.sentry.core.SentryLevel;
-        public static ERROR: io.sentry.core.SentryLevel;
-        public static FATAL: io.sentry.core.SentryLevel;
-        public static values(): native.Array<io.sentry.core.SentryLevel>;
-        public static valueOf(param0: string): io.sentry.core.SentryLevel;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SentryOptions {
-        public static class: java.lang.Class<io.sentry.core.SentryOptions>;
-        public getEventProcessors(): java.util.List<io.sentry.core.EventProcessor>;
-        public isDebug(): boolean;
-        public getShutdownTimeout(): number;
-        public setServerName(param0: string): void;
-        public addInAppExclude(param0: string): void;
-        public constructor();
-        public setMaxBreadcrumbs(param0: number): void;
-        public setShutdownTimeout(param0: number): void;
-        public getBeforeBreadcrumb(): io.sentry.core.SentryOptions.BeforeBreadcrumbCallback;
-        public getEnvironment(): string;
-        public getInAppIncludes(): java.util.List<string>;
-        public getDiagnosticLevel(): io.sentry.core.SentryLevel;
-        public getRelease(): string;
-        public getTransportGate(): io.sentry.core.transport.ITransportGate;
-        public setRelease(param0: string): void;
-        public getDsn(): string;
-        public getOutboxPath(): string;
-        public getInAppExcludes(): java.util.List<string>;
-        public setSampleRate(param0: java.lang.Double): void;
-        public addInAppInclude(param0: string): void;
-        public isAttachThreads(): boolean;
-        public getIntegrations(): java.util.List<io.sentry.core.Integration>;
-        public setTransport(param0: io.sentry.core.transport.ITransport): void;
-        public setBeforeSend(param0: io.sentry.core.SentryOptions.BeforeSendCallback): void;
-        public setAttachStacktrace(param0: boolean): void;
-        public setLogger(param0: io.sentry.core.ILogger): void;
-        public setSerializer(param0: io.sentry.core.ISerializer): void;
-        public setEnvironment(param0: string): void;
-        public addEventProcessor(param0: io.sentry.core.EventProcessor): void;
-        public getSampleRate(): java.lang.Double;
-        public getCacheDirSize(): number;
-        public addIntegration(param0: io.sentry.core.Integration): void;
-        public getLogger(): io.sentry.core.ILogger;
-        public getServerName(): string;
-        public setAttachThreads(param0: boolean): void;
-        public getCacheDirPath(): string;
-        public getTransport(): io.sentry.core.transport.ITransport;
-        public setDebug(param0: boolean): void;
-        public getDist(): string;
-        public setProxy(param0: java.net.Proxy): void;
-        public setEnableNdk(param0: boolean): void;
-        public setDiagnosticLevel(param0: io.sentry.core.SentryLevel): void;
-        public getMaxBreadcrumbs(): number;
-        public setSentryClientName(param0: string): void;
-        public isAttachStacktrace(): boolean;
-        public setTransportGate(param0: io.sentry.core.transport.ITransportGate): void;
-        public setCacheDirSize(param0: number): void;
-        public getSerializer(): io.sentry.core.ISerializer;
-        public setDsn(param0: string): void;
-        public getSentryClientName(): string;
-        public setCacheDirPath(param0: string): void;
-        public setBeforeBreadcrumb(param0: io.sentry.core.SentryOptions.BeforeBreadcrumbCallback): void;
-        public getProxy(): java.net.Proxy;
-        public setDist(param0: string): void;
-        public isEnableNdk(): boolean;
-        public getBeforeSend(): io.sentry.core.SentryOptions.BeforeSendCallback;
-      }
-      export module SentryOptions {
-        export class BeforeBreadcrumbCallback {
-          public static class: java.lang.Class<io.sentry.core.SentryOptions.BeforeBreadcrumbCallback>;
-          /**
-           * Constructs a new instance of the io.sentry.core.SentryOptions$BeforeBreadcrumbCallback interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-           */
-          public constructor(implementation: {
-            execute(param0: io.sentry.core.Breadcrumb, param1: any): io.sentry.core.Breadcrumb;
-          });
-          public constructor();
-          public execute(param0: io.sentry.core.Breadcrumb, param1: any): io.sentry.core.Breadcrumb;
-        }
-        export class BeforeSendCallback {
-          public static class: java.lang.Class<io.sentry.core.SentryOptions.BeforeSendCallback>;
-          /**
-           * Constructs a new instance of the io.sentry.core.SentryOptions$BeforeSendCallback interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-           */
-          public constructor(implementation: {
-            execute(param0: io.sentry.core.SentryEvent, param1: any): io.sentry.core.SentryEvent;
-          });
-          public constructor();
-          public execute(param0: io.sentry.core.SentryEvent, param1: any): io.sentry.core.SentryEvent;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SentryStackTraceFactory {
-        public static class: java.lang.Class<io.sentry.core.SentryStackTraceFactory>;
-        public constructor(param0: java.util.List<string>, param1: java.util.List<string>);
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SentryThreadFactory {
-        public static class: java.lang.Class<io.sentry.core.SentryThreadFactory>;
-        public constructor(param0: io.sentry.core.SentryStackTraceFactory, param1: boolean);
-        public constructor(param0: io.sentry.core.SentryStackTraceFactory);
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SentryValues<T>  extends java.lang.Object {
-        public static class: java.lang.Class<io.sentry.core.SentryValues<any>>;
-        public getValues(): java.util.List<T>;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SynchronizedCollection<E>  extends java.lang.Object {
-        public static class: java.lang.Class<io.sentry.core.SynchronizedCollection<any>>;
-        public addAll(param0: java.util.Collection<any>): boolean;
-        public contains(param0: any): boolean;
-        public toArray(param0: native.Array<any>): native.Array<any>;
-        public toString(): string;
-        public retainAll(param0: java.util.Collection<any>): boolean;
-        public toArray(): native.Array<any>;
-        public size(): number;
-        public containsAll(param0: java.util.Collection<any>): boolean;
-        public add(param0: E): boolean;
-        public hashCode(): number;
-        public removeAll(param0: java.util.Collection<any>): boolean;
-        public clear(): void;
-        public equals(param0: any): boolean;
-        public static synchronizedCollection(param0: java.util.Collection<any>): io.sentry.core.SynchronizedCollection<any>;
-        public iterator(): java.util.Iterator<E>;
-        public decorated(): java.util.Collection<E>;
-        public isEmpty(): boolean;
-        public remove(param0: any): boolean;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SynchronizedQueue<E>  extends io.sentry.core.SynchronizedCollection<any> implements java.util.Queue<any>  {
-        public static class: java.lang.Class<io.sentry.core.SynchronizedQueue<any>>;
-        public remove(): any;
-        public decorated(): java.util.Queue<any>;
-        public element(): any;
-        public hashCode(): number;
-        public peek(): any;
-        public offer(param0: any): boolean;
-        public decorated(): java.util.Collection<any>;
-        public equals(param0: any): boolean;
-        public constructor(param0: java.util.Queue<any>, param1: any);
-        public remove(param0: any): boolean;
-        public poll(): any;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class SystemOutLogger extends io.sentry.core.ILogger {
-        public static class: java.lang.Class<io.sentry.core.SystemOutLogger>;
-        public log(param0: io.sentry.core.SentryLevel, param1: string, param2: native.Array<any>): void;
-        public log(param0: io.sentry.core.SentryLevel, param1: string, param2: java.lang.Throwable): void;
-        public constructor();
-        public log(param0: io.sentry.core.SentryLevel, param1: java.lang.Throwable, param2: string, param3: native.Array<any>): void;
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class UncaughtExceptionHandler {
-        public static class: java.lang.Class<io.sentry.core.UncaughtExceptionHandler>;
-        /**
-         * Constructs a new instance of the io.sentry.core.UncaughtExceptionHandler interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-         */
-        public constructor(implementation: {
-          getDefaultUncaughtExceptionHandler(): java.lang.Thread.UncaughtExceptionHandler;
-          setDefaultUncaughtExceptionHandler(param0: java.lang.Thread.UncaughtExceptionHandler): void;
-        });
-        public constructor();
-        public setDefaultUncaughtExceptionHandler(param0: java.lang.Thread.UncaughtExceptionHandler): void;
-        public getDefaultUncaughtExceptionHandler(): java.lang.Thread.UncaughtExceptionHandler;
-      }
-      export module UncaughtExceptionHandler {
-        export class Adapter extends io.sentry.core.UncaughtExceptionHandler {
-          public static class: java.lang.Class<io.sentry.core.UncaughtExceptionHandler.Adapter>;
-          public getDefaultUncaughtExceptionHandler(): java.lang.Thread.UncaughtExceptionHandler;
-          public setDefaultUncaughtExceptionHandler(param0: java.lang.Thread.UncaughtExceptionHandler): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export class UncaughtExceptionHandlerIntegration extends io.sentry.core.Integration {
-        public static class: java.lang.Class<io.sentry.core.UncaughtExceptionHandlerIntegration>;
-        public close(): void;
-        public register(param0: io.sentry.core.IHub, param1: io.sentry.core.SentryOptions): void;
-        public uncaughtException(param0: java.lang.Thread, param1: java.lang.Throwable): void;
-      }
-      export module UncaughtExceptionHandlerIntegration {
-        export class UncaughtExceptionHint extends io.sentry.core.hints.DiskFlushNotification {
-          public static class: java.lang.Class<io.sentry.core.UncaughtExceptionHandlerIntegration.UncaughtExceptionHint>;
-          public markFlushed(): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module cache {
-        export class DiskCache extends io.sentry.core.cache.IEventCache {
-          public static class: java.lang.Class<io.sentry.core.cache.DiskCache>;
-          public static FILE_SUFFIX: string;
-          public iterator(): java.util.Iterator<io.sentry.core.SentryEvent>;
-          public discard(param0: io.sentry.core.SentryEvent): void;
-          public store(param0: io.sentry.core.SentryEvent): void;
-          public constructor(param0: io.sentry.core.SentryOptions);
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module cache {
-        export class IEventCache extends java.lang.Iterable<io.sentry.core.SentryEvent> {
-          public static class: java.lang.Class<io.sentry.core.cache.IEventCache>;
-          /**
-           * Constructs a new instance of the io.sentry.core.cache.IEventCache interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-           */
-          public constructor(implementation: {
-            store(param0: io.sentry.core.SentryEvent): void;
-            discard(param0: io.sentry.core.SentryEvent): void;
-          });
-          public constructor();
-          public discard(param0: io.sentry.core.SentryEvent): void;
-          public store(param0: io.sentry.core.SentryEvent): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module exception {
-        export class ExceptionMechanismException {
-          public static class: java.lang.Class<io.sentry.core.exception.ExceptionMechanismException>;
-          public getThrowable(): java.lang.Throwable;
-          public getExceptionMechanism(): io.sentry.core.protocol.Mechanism;
-          public constructor(param0: io.sentry.core.protocol.Mechanism, param1: java.lang.Throwable, param2: java.lang.Thread);
-          public getThread(): java.lang.Thread;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module hints {
-        export class Cached {
-          public static class: java.lang.Class<io.sentry.core.hints.Cached>;
-          /**
-           * Constructs a new instance of the io.sentry.core.hints.Cached interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-           */
-          public constructor(implementation: {
-          });
-          public constructor();
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module hints {
-        export class DiskFlushNotification {
-          public static class: java.lang.Class<io.sentry.core.hints.DiskFlushNotification>;
-          /**
-           * Constructs a new instance of the io.sentry.core.hints.DiskFlushNotification interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-           */
-          public constructor(implementation: {
-            markFlushed(): void;
-          });
-          public constructor();
-          public markFlushed(): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module hints {
-        export class Retryable {
-          public static class: java.lang.Class<io.sentry.core.hints.Retryable>;
-          /**
-           * Constructs a new instance of the io.sentry.core.hints.Retryable interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-           */
-          public constructor(implementation: {
-            getRetry(): boolean;
-            setRetry(param0: boolean): void;
-          });
-          public constructor();
-          public setRetry(param0: boolean): void;
-          public getRetry(): boolean;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module hints {
-        export class SubmissionResult {
-          public static class: java.lang.Class<io.sentry.core.hints.SubmissionResult>;
-          /**
-           * Constructs a new instance of the io.sentry.core.hints.SubmissionResult interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-           */
-          public constructor(implementation: {
-            setResult(param0: boolean): void;
-          });
-          public constructor();
-          public setResult(param0: boolean): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class App extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.App>;
-          public static TYPE: string;
-          public getAppIdentifier(): string;
-          public setAppBuild(param0: string): void;
-          public getAppName(): string;
-          public setAppStartTime(param0: java.util.Date): void;
-          public setDeviceAppHash(param0: string): void;
-          public getBuildType(): string;
-          public setBuildType(param0: string): void;
-          public getAppBuild(): string;
-          public getAppVersion(): string;
-          public setAppVersion(param0: string): void;
-          public constructor();
-          public getAppStartTime(): java.util.Date;
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public getDeviceAppHash(): string;
-          public setAppIdentifier(param0: string): void;
-          public setAppName(param0: string): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class Browser extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.Browser>;
-          public static TYPE: string;
-          public setVersion(param0: string): void;
-          public getVersion(): string;
-          public constructor();
-          public getName(): string;
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public setName(param0: string): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class Contexts extends java.util.concurrent.ConcurrentHashMap<string,any> {
-          public static class: java.lang.Class<io.sentry.core.protocol.Contexts>;
-          public setGpu(param0: io.sentry.core.protocol.Gpu): void;
-          public setDevice(param0: io.sentry.core.protocol.Device): void;
-          public getRuntime(): io.sentry.core.protocol.SentryRuntime;
-          public getGpu(): io.sentry.core.protocol.Gpu;
-          public getApp(): io.sentry.core.protocol.App;
-          public setOperatingSystem(param0: io.sentry.core.protocol.OperatingSystem): void;
-          public getBrowser(): io.sentry.core.protocol.Browser;
-          public setApp(param0: io.sentry.core.protocol.App): void;
-          public getDevice(): io.sentry.core.protocol.Device;
-          public getOperatingSystem(): io.sentry.core.protocol.OperatingSystem;
-          public constructor();
-          public setRuntime(param0: io.sentry.core.protocol.SentryRuntime): void;
-          public setBrowser(param0: io.sentry.core.protocol.Browser): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class DebugImage extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.DebugImage>;
-          public getImageAddr(): string;
-          public getCodeId(): string;
-          public setImageSize(param0: java.lang.Long): void;
-          public setType(param0: string): void;
-          public setDebugId(param0: string): void;
-          public setUuid(param0: string): void;
-          public getDebugFile(): string;
-          public setCodeFile(param0: string): void;
-          public setDebugFile(param0: string): void;
-          public getCodeFile(): string;
-          public getDebugId(): string;
-          public setImageAddr(param0: string): void;
-          public constructor();
-          public setArch(param0: string): void;
-          public getArch(): string;
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public getUuid(): string;
-          public getType(): string;
-          public getImageSize(): java.lang.Long;
-          public setCodeId(param0: string): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class DebugMeta extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.DebugMeta>;
-          public getSdkInfo(): io.sentry.core.protocol.SdkInfo;
-          public getImages(): java.util.List<io.sentry.core.protocol.DebugImage>;
-          public constructor();
-          public setSdkInfo(param0: io.sentry.core.protocol.SdkInfo): void;
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public setImages(param0: java.util.List<io.sentry.core.protocol.DebugImage>): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class Device extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.Device>;
-          public static TYPE: string;
-          public getFreeMemory(): java.lang.Long;
-          public setOnline(param0: java.lang.Boolean): void;
-          public getId(): string;
-          public getModel(): string;
-          public isOnline(): java.lang.Boolean;
-          public getScreenDpi(): java.lang.Integer;
-          public isSimulator(): java.lang.Boolean;
-          public getUsableMemory(): java.lang.Long;
-          public getScreenDensity(): java.lang.Float;
-          public constructor();
-          public setMemorySize(param0: java.lang.Long): void;
-          public setFamily(param0: string): void;
-          /** @deprecated */
-          public getArch(): string;
-          public getScreenWidthPixels(): java.lang.Integer;
-          public setArchs(param0: native.Array<string>): void;
-          public setConnectionType(param0: string): void;
-          public setExternalFreeStorage(param0: java.lang.Long): void;
-          public setTimezone(param0: java.util.TimeZone): void;
-          public setOrientation(param0: io.sentry.core.protocol.Device.DeviceOrientation): void;
-          public getBrand(): string;
-          public getFamily(): string;
-          public setScreenWidthPixels(param0: java.lang.Integer): void;
-          public getMemorySize(): java.lang.Long;
-          public getBootTime(): java.util.Date;
-          /** @deprecated */
-          public setArch(param0: string): void;
-          public setName(param0: string): void;
-          public isCharging(): java.lang.Boolean;
-          public setLanguage(param0: string): void;
-          public getExternalFreeStorage(): java.lang.Long;
-          public setManufacturer(param0: string): void;
-          public setBatteryLevel(param0: java.lang.Float): void;
-          public setScreenDpi(param0: java.lang.Integer): void;
-          public setScreenHeightPixels(param0: java.lang.Integer): void;
-          public setModel(param0: string): void;
-          public getModelId(): string;
-          public setExternalStorageSize(param0: java.lang.Long): void;
-          public isLowMemory(): java.lang.Boolean;
-          public getConnectionType(): string;
-          public getStorageSize(): java.lang.Long;
-          public setFreeStorage(param0: java.lang.Long): void;
-          public setSimulator(param0: java.lang.Boolean): void;
-          public getTimezone(): java.util.TimeZone;
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public getScreenHeightPixels(): java.lang.Integer;
-          public setModelId(param0: string): void;
-          /** @deprecated */
-          public getScreenResolution(): string;
-          /** @deprecated */
-          public setScreenResolution(param0: string): void;
-          public setCharging(param0: java.lang.Boolean): void;
-          public getBatteryLevel(): java.lang.Float;
-          public getArchs(): native.Array<string>;
-          public getOrientation(): io.sentry.core.protocol.Device.DeviceOrientation;
-          public setScreenDensity(param0: java.lang.Float): void;
-          public getManufacturer(): string;
-          public getFreeStorage(): java.lang.Long;
-          public setUsableMemory(param0: java.lang.Long): void;
-          public getExternalStorageSize(): java.lang.Long;
-          public setBrand(param0: string): void;
-          public getName(): string;
-          public setFreeMemory(param0: java.lang.Long): void;
-          public setId(param0: string): void;
-          public getLanguage(): string;
-          public setStorageSize(param0: java.lang.Long): void;
-          public setLowMemory(param0: java.lang.Boolean): void;
-          public setBootTime(param0: java.util.Date): void;
-        }
-        export module Device {
-          export class DeviceOrientation {
-            public static class: java.lang.Class<io.sentry.core.protocol.Device.DeviceOrientation>;
-            public static PORTRAIT: io.sentry.core.protocol.Device.DeviceOrientation;
-            public static LANDSCAPE: io.sentry.core.protocol.Device.DeviceOrientation;
-            public static valueOf(param0: string): io.sentry.core.protocol.Device.DeviceOrientation;
-            public static values(): native.Array<io.sentry.core.protocol.Device.DeviceOrientation>;
-          }
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class Gpu extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.Gpu>;
-          public static TYPE: string;
-          public getVersion(): string;
-          public getApiType(): string;
-          public setApiType(param0: string): void;
-          public getVendorName(): string;
-          public setId(param0: java.lang.Integer): void;
-          public getVendorId(): java.lang.Integer;
-          public setVendorId(param0: java.lang.Integer): void;
-          public setNpotSupport(param0: string): void;
-          public getMemorySize(): java.lang.Integer;
-          public setName(param0: string): void;
-          public getNpotSupport(): string;
-          public setVersion(param0: string): void;
-          public setMultiThreadedRendering(param0: java.lang.Boolean): void;
-          public constructor();
-          public getName(): string;
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public setMemorySize(param0: java.lang.Integer): void;
-          public isMultiThreadedRendering(): java.lang.Boolean;
-          public setVendorName(param0: string): void;
-          public getId(): java.lang.Integer;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class Mechanism extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.Mechanism>;
-          public setDescription(param0: string): void;
-          public constructor(param0: java.lang.Thread);
-          public setType(param0: string): void;
-          public setHelpLink(param0: string): void;
-          public isHandled(): java.lang.Boolean;
-          public setSynthetic(param0: java.lang.Boolean): void;
-          public getMeta(): java.util.Map<string,any>;
-          public getSynthetic(): java.lang.Boolean;
-          public getHelpLink(): string;
-          public getData(): java.util.Map<string,any>;
-          public setMeta(param0: java.util.Map<string,any>): void;
-          public constructor();
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public setData(param0: java.util.Map<string,any>): void;
-          public getType(): string;
-          public getDescription(): string;
-          public setHandled(param0: java.lang.Boolean): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class Message extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.Message>;
-          public setFormatted(param0: string): void;
-          public constructor();
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public getMessage(): string;
-          public getParams(): java.util.List<string>;
-          public setMessage(param0: string): void;
-          public getFormatted(): string;
-          public setParams(param0: java.util.List<string>): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class OperatingSystem extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.OperatingSystem>;
-          public static TYPE: string;
-          public getVersion(): string;
-          public setKernelVersion(param0: string): void;
-          public isRooted(): java.lang.Boolean;
-          public setRooted(param0: java.lang.Boolean): void;
-          public getKernelVersion(): string;
-          public setName(param0: string): void;
-          public setVersion(param0: string): void;
-          public setBuild(param0: string): void;
-          public constructor();
-          public getName(): string;
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public getRawDescription(): string;
-          public setRawDescription(param0: string): void;
-          public getBuild(): string;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class Request extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.Request>;
-          public setCookies(param0: string): void;
-          public getHeaders(): java.util.Map<string,string>;
-          public getData(): any;
-          public setEnvs(param0: java.util.Map<string,string>): void;
-          public getOthers(): java.util.Map<string,string>;
-          public setData(param0: any): void;
-          public getUrl(): string;
-          public constructor();
-          public getCookies(): string;
-          public setUrl(param0: string): void;
-          public getQueryString(): string;
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public setMethod(param0: string): void;
-          public getEnvs(): java.util.Map<string,string>;
-          public setOthers(param0: java.util.Map<string,string>): void;
-          public getMethod(): string;
-          public setQueryString(param0: string): void;
-          public setHeaders(param0: java.util.Map<string,string>): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class SdkInfo extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.SdkInfo>;
-          public setVersionMinor(param0: java.lang.Integer): void;
-          public setSdkName(param0: string): void;
-          public constructor();
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public setVersionPatchlevel(param0: java.lang.Integer): void;
-          public getVersionMajor(): java.lang.Integer;
-          public setVersionMajor(param0: java.lang.Integer): void;
-          public getVersionMinor(): java.lang.Integer;
-          public getSdkName(): string;
-          public getVersionPatchlevel(): java.lang.Integer;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class SdkVersion extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.SdkVersion>;
-          public setVersion(param0: string): void;
-          public getVersion(): string;
-          public constructor();
-          public getName(): string;
-          public addPackage(param0: string, param1: string): void;
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public addIntegration(param0: string): void;
-          public setName(param0: string): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class SentryException extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.SentryException>;
-          public getModule(): string;
-          public setType(param0: string): void;
-          public setModule(param0: string): void;
-          public setValue(param0: string): void;
-          public setStacktrace(param0: io.sentry.core.protocol.SentryStackTrace): void;
-          public getThreadId(): java.lang.Long;
-          public setThreadId(param0: java.lang.Long): void;
-          public getValue(): string;
-          public constructor();
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public getType(): string;
-          public getStacktrace(): io.sentry.core.protocol.SentryStackTrace;
-          public getMechanism(): io.sentry.core.protocol.Mechanism;
-          public setMechanism(param0: io.sentry.core.protocol.Mechanism): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class SentryId {
-          public static class: java.lang.Class<io.sentry.core.protocol.SentryId>;
-          public static EMPTY_ID: io.sentry.core.protocol.SentryId;
-          public equals(param0: any): boolean;
-          public toString(): string;
-          public constructor(param0: string);
-          public constructor();
-          public hashCode(): number;
-          public constructor(param0: java.util.UUID);
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class SentryPackage extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.SentryPackage>;
-          public setVersion(param0: string): void;
-          public getVersion(): string;
-          public constructor();
-          public getName(): string;
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public setName(param0: string): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class SentryRuntime extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.SentryRuntime>;
-          public static TYPE: string;
-          public setVersion(param0: string): void;
-          public getVersion(): string;
-          public constructor();
-          public getName(): string;
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public getRawDescription(): string;
-          public setRawDescription(param0: string): void;
-          public setName(param0: string): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class SentryStackFrame extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.SentryStackFrame>;
-          public getPreContext(): java.util.List<string>;
-          public getFunction(): string;
-          public setInApp(param0: java.lang.Boolean): void;
-          public getColno(): java.lang.Integer;
-          public getFramesOmitted(): java.util.List<java.lang.Integer>;
-          public setFunction(param0: string): void;
-          public setModule(param0: string): void;
-          public isInApp(): java.lang.Boolean;
-          public setPlatform(param0: string): void;
-          public setContextLine(param0: string): void;
-          public setLineno(param0: java.lang.Integer): void;
-          public getPostContext(): java.util.List<string>;
-          public setPackage(param0: string): void;
-          public setSymbolAddr(param0: string): void;
-          public getRawFunction(): string;
-          public constructor();
-          public setPostContext(param0: java.util.List<string>): void;
-          public getVars(): java.util.Map<string,string>;
-          public getFilename(): string;
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public isNative(): java.lang.Boolean;
-          public getInstructionAddr(): string;
-          public getSymbolAddr(): string;
-          public getImageAddr(): string;
-          public setColno(param0: java.lang.Integer): void;
-          public getModule(): string;
-          public getLineno(): java.lang.Integer;
-          public setNative(param0: java.lang.Boolean): void;
-          public setRawFunction(param0: string): void;
-          public getPlatform(): string;
-          public setVars(param0: java.util.Map<string,string>): void;
-          public setFilename(param0: string): void;
-          public setAbsPath(param0: string): void;
-          public getAbsPath(): string;
-          public getPackage(): string;
-          public setImageAddr(param0: string): void;
-          public setFramesOmitted(param0: java.util.List<java.lang.Integer>): void;
-          public setInstructionAddr(param0: string): void;
-          public setPreContext(param0: java.util.List<string>): void;
-          public getContextLine(): string;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class SentryStackTrace extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.SentryStackTrace>;
-          public constructor(param0: java.util.List<io.sentry.core.protocol.SentryStackFrame>);
-          public getFrames(): java.util.List<io.sentry.core.protocol.SentryStackFrame>;
-          public constructor();
-          public getRegisters(): java.util.Map<string,string>;
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public setFrames(param0: java.util.List<io.sentry.core.protocol.SentryStackFrame>): void;
-          public setRegisters(param0: java.util.Map<string,string>): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class SentryThread extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.SentryThread>;
-          public setState(param0: string): void;
-          public setCrashed(param0: java.lang.Boolean): void;
-          public setCurrent(param0: java.lang.Boolean): void;
-          public getState(): string;
-          public getId(): java.lang.Long;
-          public setName(param0: string): void;
-          public setStacktrace(param0: io.sentry.core.protocol.SentryStackTrace): void;
-          public constructor();
-          public setId(param0: java.lang.Long): void;
-          public getName(): string;
-          public setDaemon(param0: java.lang.Boolean): void;
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public isCrashed(): java.lang.Boolean;
-          public isCurrent(): java.lang.Boolean;
-          public getPriority(): java.lang.Integer;
-          public getStacktrace(): io.sentry.core.protocol.SentryStackTrace;
-          public setPriority(param0: java.lang.Integer): void;
-          public isDaemon(): java.lang.Boolean;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module protocol {
-        export class User extends io.sentry.core.IUnknownPropertiesConsumer {
-          public static class: java.lang.Class<io.sentry.core.protocol.User>;
-          public getId(): string;
-          public getOthers(): java.util.Map<string,string>;
-          public clone(): io.sentry.core.protocol.User;
-          public setIpAddress(param0: string): void;
-          public getUsername(): string;
-          public getIpAddress(): string;
-          public setUsername(param0: string): void;
-          public constructor();
-          public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
-          public setId(param0: string): void;
-          public setOthers(param0: java.util.Map<string,string>): void;
-          public getEmail(): string;
-          public setEmail(param0: string): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module transport {
-        export class AsyncConnection extends io.sentry.core.transport.Connection {
-          public static class: java.lang.Class<io.sentry.core.transport.AsyncConnection>;
-          public close(): void;
-          public send(param0: io.sentry.core.SentryEvent): void;
-          public send(param0: io.sentry.core.SentryEvent, param1: any): void;
-          public constructor(param0: io.sentry.core.transport.ITransport, param1: io.sentry.core.transport.ITransportGate, param2: io.sentry.core.cache.IEventCache, param3: number, param4: io.sentry.core.SentryOptions);
-        }
-        export module AsyncConnection {
-          export class AsyncConnectionThreadFactory {
-            public static class: java.lang.Class<io.sentry.core.transport.AsyncConnection.AsyncConnectionThreadFactory>;
-            public newThread(param0: java.lang.Runnable): java.lang.Thread;
-          }
-          export class EventSender extends io.sentry.core.transport.Retryable {
-            public static class: java.lang.Class<io.sentry.core.transport.AsyncConnection.EventSender>;
-            public run(): void;
-            public getSuggestedRetryDelayMillis(): number;
-            public getResponseCode(): number;
-          }
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module transport {
-        export class Connection {
-          public static class: java.lang.Class<io.sentry.core.transport.Connection>;
-          /**
-           * Constructs a new instance of the io.sentry.core.transport.Connection interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-           */
-          public constructor(implementation: {
-            send(param0: io.sentry.core.SentryEvent, param1: any): void;
-            send(param0: io.sentry.core.SentryEvent): void;
-            close(): void;
-          });
-          public constructor();
-          public close(): void;
-          public send(param0: io.sentry.core.SentryEvent): void;
-          public send(param0: io.sentry.core.SentryEvent, param1: any): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module transport {
-        export class HttpTransport extends io.sentry.core.transport.ITransport {
-          public static class: java.lang.Class<io.sentry.core.transport.HttpTransport>;
-          public send(param0: io.sentry.core.SentryEvent): io.sentry.core.transport.TransportResult;
-          public constructor(param0: io.sentry.core.SentryOptions, param1: io.sentry.core.transport.IConnectionConfigurator, param2: number, param3: number, param4: boolean, param5: java.net.URL);
-          public close(): void;
-          public open(param0: java.net.Proxy): java.net.HttpURLConnection;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module transport {
-        export class IConnectionConfigurator {
-          public static class: java.lang.Class<io.sentry.core.transport.IConnectionConfigurator>;
-          /**
-           * Constructs a new instance of the io.sentry.core.transport.IConnectionConfigurator interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-           */
-          public constructor(implementation: {
-            configure(param0: java.net.HttpURLConnection): void;
-          });
-          public constructor();
-          public configure(param0: java.net.HttpURLConnection): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module transport {
-        export class ITransport {
-          public static class: java.lang.Class<io.sentry.core.transport.ITransport>;
-          /**
-           * Constructs a new instance of the io.sentry.core.transport.ITransport interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-           */
-          public constructor(implementation: {
-            send(param0: io.sentry.core.SentryEvent): io.sentry.core.transport.TransportResult;
-          });
-          public constructor();
-          public send(param0: io.sentry.core.SentryEvent): io.sentry.core.transport.TransportResult;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module transport {
-        export class ITransportGate {
-          public static class: java.lang.Class<io.sentry.core.transport.ITransportGate>;
-          /**
-           * Constructs a new instance of the io.sentry.core.transport.ITransportGate interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-           */
-          public constructor(implementation: {
-            isSendingAllowed(): boolean;
-          });
-          public constructor();
-          public isSendingAllowed(): boolean;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module transport {
-        export class NoOpEventCache extends io.sentry.core.cache.IEventCache {
-          public static class: java.lang.Class<io.sentry.core.transport.NoOpEventCache>;
-          public static getInstance(): io.sentry.core.transport.NoOpEventCache;
-          public iterator(): java.util.Iterator<io.sentry.core.SentryEvent>;
-          public discard(param0: io.sentry.core.SentryEvent): void;
-          public store(param0: io.sentry.core.SentryEvent): void;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module transport {
-        export class Retryable {
-          public static class: java.lang.Class<io.sentry.core.transport.Retryable>;
-          /**
-           * Constructs a new instance of the io.sentry.core.transport.Retryable interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
-           */
-          public constructor(implementation: {
-            getSuggestedRetryDelayMillis(): number;
-            getResponseCode(): number;
-          });
-          public constructor();
-          public getResponseCode(): number;
-          public getSuggestedRetryDelayMillis(): number;
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module transport {
-        export class RetryingThreadPoolExecutor {
-          public static class: java.lang.Class<io.sentry.core.transport.RetryingThreadPoolExecutor>;
-          public afterExecute(param0: java.lang.Runnable, param1: java.lang.Throwable): void;
-          public constructor(param0: number, param1: number, param2: java.util.concurrent.ThreadFactory, param3: java.util.concurrent.RejectedExecutionHandler);
-          public submit(param0: java.lang.Runnable): java.util.concurrent.Future<any>;
-          public beforeExecute(param0: java.lang.Thread, param1: java.lang.Runnable): void;
-          public submit(param0: io.sentry.core.transport.Retryable): void;
-          public decorateTask(param0: java.lang.Runnable, param1: java.util.concurrent.RunnableScheduledFuture<any>): java.util.concurrent.RunnableScheduledFuture<any>;
-          public submit(param0: java.lang.Runnable, param1: any): java.util.concurrent.Future<any>;
-          public submit(param0: java.util.concurrent.Callable<any>): java.util.concurrent.Future<any>;
-        }
-        export module RetryingThreadPoolExecutor {
-          export class AttemptedRunnable<V>  extends java.util.concurrent.RunnableScheduledFuture<any> {
-            public static class: java.lang.Class<io.sentry.core.transport.RetryingThreadPoolExecutor.AttemptedRunnable<any>>;
-            public isDone(): boolean;
-            public isPeriodic(): boolean;
-            public run(): void;
-            public isCancelled(): boolean;
-            public getDelay(param0: java.util.concurrent.TimeUnit): number;
-            public cancel(param0: boolean): boolean;
-            public equals(param0: any): boolean;
-            public hashCode(): number;
-            public get(param0: number, param1: java.util.concurrent.TimeUnit): any;
-            public compareTo(param0: java.util.concurrent.Delayed): number;
-            public get(): any;
-            public toString(): string;
-          }
-          export class CancelledFuture<T>  extends java.util.concurrent.Future<any> {
-            public static class: java.lang.Class<io.sentry.core.transport.RetryingThreadPoolExecutor.CancelledFuture<any>>;
-            public isDone(): boolean;
-            public isCancelled(): boolean;
-            public cancel(param0: boolean): boolean;
-            public get(param0: number, param1: java.util.concurrent.TimeUnit): any;
-            public get(): any;
-          }
-          export class NextAttempt {
-            public static class: java.lang.Class<io.sentry.core.transport.RetryingThreadPoolExecutor.NextAttempt>;
-            public run(): void;
-          }
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module transport {
-        export abstract class TransportResult {
-          public static class: java.lang.Class<io.sentry.core.transport.TransportResult>;
-          public getResponseCode(): number;
-          public getRetryMillis(): number;
-          public static success(): io.sentry.core.transport.TransportResult;
-          public static error(param0: number, param1: number): io.sentry.core.transport.TransportResult;
-          public isSuccess(): boolean;
-        }
-        export module TransportResult {
-          export class ErrorTransportResult extends io.sentry.core.transport.TransportResult {
-            public static class: java.lang.Class<io.sentry.core.transport.TransportResult.ErrorTransportResult>;
-            public isSuccess(): boolean;
-            public getResponseCode(): number;
-            public getRetryMillis(): number;
-          }
-          export class SuccessTransportResult extends io.sentry.core.transport.TransportResult {
-            public static class: java.lang.Class<io.sentry.core.transport.TransportResult.SuccessTransportResult>;
-            public isSuccess(): boolean;
-            public getResponseCode(): number;
-            public getRetryMillis(): number;
-          }
-        }
-      }
-    }
-  }
-}
-
-declare module io {
-  export module sentry {
-    export module core {
-      export module util {
-        export class Objects {
-          public static class: java.lang.Class<io.sentry.core.util.Objects>;
-          public static requireNonNull(param0: any, param1: string): any;
-        }
-      }
-    }
-  }
+	export module sentry {
+		export module protocol {
+			export class SentryPackage extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.SentryPackage>;
+				public setName(param0: string): void;
+				public getVersion(): string;
+				/** @deprecated */
+				public constructor();
+				public getName(): string;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public setVersion(param0: string): void;
+				public constructor(param0: string, param1: string);
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class SentryRuntime extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.SentryRuntime>;
+				public static TYPE: string;
+				public setName(param0: string): void;
+				public getVersion(): string;
+				public getRawDescription(): string;
+				public clone(): io.sentry.protocol.SentryRuntime;
+				public setRawDescription(param0: string): void;
+				public getName(): string;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public setVersion(param0: string): void;
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class SentryStackFrame extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.SentryStackFrame>;
+				public setFramesOmitted(param0: java.util.List<java.lang.Integer>): void;
+				public getModule(): string;
+				public setModule(param0: string): void;
+				public setPostContext(param0: java.util.List<string>): void;
+				public getAbsPath(): string;
+				public getFunction(): string;
+				public setVars(param0: java.util.Map<string,string>): void;
+				public getVars(): java.util.Map<string,string>;
+				public setPackage(param0: string): void;
+				public getPreContext(): java.util.List<string>;
+				public setAbsPath(param0: string): void;
+				public constructor();
+				public setColno(param0: java.lang.Integer): void;
+				public setImageAddr(param0: string): void;
+				public setNative(param0: java.lang.Boolean): void;
+				public setRawFunction(param0: string): void;
+				public getFilename(): string;
+				public setPlatform(param0: string): void;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public getPackage(): string;
+				public setFunction(param0: string): void;
+				public getLineno(): java.lang.Integer;
+				public setInApp(param0: java.lang.Boolean): void;
+				public getFramesOmitted(): java.util.List<java.lang.Integer>;
+				public setSymbolAddr(param0: string): void;
+				public getPostContext(): java.util.List<string>;
+				public getContextLine(): string;
+				public getSymbolAddr(): string;
+				public setInstructionAddr(param0: string): void;
+				public getRawFunction(): string;
+				public setLineno(param0: java.lang.Integer): void;
+				public setContextLine(param0: string): void;
+				public setFilename(param0: string): void;
+				public getPlatform(): string;
+				public getInstructionAddr(): string;
+				public getImageAddr(): string;
+				public setPreContext(param0: java.util.List<string>): void;
+				public getColno(): java.lang.Integer;
+				public isInApp(): java.lang.Boolean;
+				public isNative(): java.lang.Boolean;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class SentryStackTrace extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.SentryStackTrace>;
+				public setRegisters(param0: java.util.Map<string,string>): void;
+				public constructor(param0: java.util.List<io.sentry.protocol.SentryStackFrame>);
+				public getRegisters(): java.util.Map<string,string>;
+				public setSnapshot(param0: java.lang.Boolean): void;
+				public setFrames(param0: java.util.List<io.sentry.protocol.SentryStackFrame>): void;
+				public getSnapshot(): java.lang.Boolean;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public constructor();
+				public getFrames(): java.util.List<io.sentry.protocol.SentryStackFrame>;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class SentryThread extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.SentryThread>;
+				public setName(param0: string): void;
+				public getPriority(): java.lang.Integer;
+				public isCrashed(): java.lang.Boolean;
+				public setDaemon(param0: java.lang.Boolean): void;
+				public setCurrent(param0: java.lang.Boolean): void;
+				public getName(): string;
+				public setCrashed(param0: java.lang.Boolean): void;
+				public setId(param0: java.lang.Long): void;
+				public isCurrent(): java.lang.Boolean;
+				public constructor();
+				public getStacktrace(): io.sentry.protocol.SentryStackTrace;
+				public getState(): string;
+				public isDaemon(): java.lang.Boolean;
+				public getId(): java.lang.Long;
+				public setStacktrace(param0: io.sentry.protocol.SentryStackTrace): void;
+				public setState(param0: string): void;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public setPriority(param0: java.lang.Integer): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module protocol {
+			export class User extends io.sentry.IUnknownPropertiesConsumer {
+				public static class: java.lang.Class<io.sentry.protocol.User>;
+				public getId(): string;
+				public getEmail(): string;
+				public getIpAddress(): string;
+				public getOthers(): java.util.Map<string,string>;
+				public setEmail(param0: string): void;
+				public clone(): io.sentry.protocol.User;
+				public constructor();
+				public setId(param0: string): void;
+				public setUsername(param0: string): void;
+				public getUsername(): string;
+				public setIpAddress(param0: string): void;
+				public acceptUnknownProperties(param0: java.util.Map<string,any>): void;
+				public setOthers(param0: java.util.Map<string,string>): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export class AsyncHttpTransport extends io.sentry.transport.ITransport {
+				public static class: java.lang.Class<io.sentry.transport.AsyncHttpTransport>;
+				public constructor(param0: io.sentry.transport.QueuedThreadPoolExecutor, param1: io.sentry.SentryOptions, param2: io.sentry.transport.RateLimiter, param3: io.sentry.transport.ITransportGate, param4: io.sentry.transport.HttpConnection);
+				public constructor(param0: io.sentry.SentryOptions, param1: io.sentry.transport.RateLimiter, param2: io.sentry.transport.ITransportGate, param3: io.sentry.RequestDetails);
+				public close(): void;
+				public send(param0: io.sentry.SentryEnvelope, param1: any): void;
+				public send(param0: io.sentry.SentryEnvelope): void;
+				public flush(param0: number): void;
+			}
+			export module AsyncHttpTransport {
+				export class AsyncConnectionThreadFactory {
+					public static class: java.lang.Class<io.sentry.transport.AsyncHttpTransport.AsyncConnectionThreadFactory>;
+					public newThread(param0: java.lang.Runnable): java.lang.Thread;
+				}
+				export class EnvelopeSender {
+					public static class: java.lang.Class<io.sentry.transport.AsyncHttpTransport.EnvelopeSender>;
+					public run(): void;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export class AuthenticatorWrapper {
+				public static class: java.lang.Class<io.sentry.transport.AuthenticatorWrapper>;
+				public setDefault(param0: java.net.Authenticator): void;
+				public static getInstance(): io.sentry.transport.AuthenticatorWrapper;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export class CurrentDateProvider extends io.sentry.transport.ICurrentDateProvider {
+				public static class: java.lang.Class<io.sentry.transport.CurrentDateProvider>;
+				public getCurrentTimeMillis(): number;
+				public static getInstance(): io.sentry.transport.ICurrentDateProvider;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export class HttpConnection {
+				public static class: java.lang.Class<io.sentry.transport.HttpConnection>;
+				public send(param0: io.sentry.SentryEnvelope): io.sentry.transport.TransportResult;
+				public updateRetryAfterLimits(param0: java.net.HttpURLConnection, param1: number): void;
+				public constructor(param0: io.sentry.SentryOptions, param1: io.sentry.RequestDetails, param2: io.sentry.transport.RateLimiter);
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export class ICurrentDateProvider {
+				public static class: java.lang.Class<io.sentry.transport.ICurrentDateProvider>;
+				/**
+				 * Constructs a new instance of the io.sentry.transport.ICurrentDateProvider interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					getCurrentTimeMillis(): number;
+				});
+				public constructor();
+				public getCurrentTimeMillis(): number;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export class ITransport {
+				public static class: java.lang.Class<io.sentry.transport.ITransport>;
+				/**
+				 * Constructs a new instance of the io.sentry.transport.ITransport interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					send(param0: io.sentry.SentryEnvelope, param1: any): void;
+					send(param0: io.sentry.SentryEnvelope): void;
+					flush(param0: number): void;
+				});
+				public constructor();
+				public send(param0: io.sentry.SentryEnvelope, param1: any): void;
+				public send(param0: io.sentry.SentryEnvelope): void;
+				public flush(param0: number): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export class ITransportGate {
+				public static class: java.lang.Class<io.sentry.transport.ITransportGate>;
+				/**
+				 * Constructs a new instance of the io.sentry.transport.ITransportGate interface with the provided implementation. An empty constructor exists calling super() when extending the interface class.
+				 */
+				public constructor(implementation: {
+					isConnected(): boolean;
+				});
+				public constructor();
+				public isConnected(): boolean;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export class NoOpEnvelopeCache extends io.sentry.cache.IEnvelopeCache {
+				public static class: java.lang.Class<io.sentry.transport.NoOpEnvelopeCache>;
+				public discard(param0: io.sentry.SentryEnvelope): void;
+				public store(param0: io.sentry.SentryEnvelope, param1: any): void;
+				public store(param0: io.sentry.SentryEnvelope): void;
+				public static getInstance(): io.sentry.transport.NoOpEnvelopeCache;
+				public iterator(): java.util.Iterator<io.sentry.SentryEnvelope>;
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export class NoOpTransport extends io.sentry.transport.ITransport {
+				public static class: java.lang.Class<io.sentry.transport.NoOpTransport>;
+				public close(): void;
+				public static getInstance(): io.sentry.transport.NoOpTransport;
+				public send(param0: io.sentry.SentryEnvelope, param1: any): void;
+				public send(param0: io.sentry.SentryEnvelope): void;
+				public flush(param0: number): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export class NoOpTransportGate extends io.sentry.transport.ITransportGate {
+				public static class: java.lang.Class<io.sentry.transport.NoOpTransportGate>;
+				public isConnected(): boolean;
+				public static getInstance(): io.sentry.transport.NoOpTransportGate;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export class ProxyAuthenticator {
+				public static class: java.lang.Class<io.sentry.transport.ProxyAuthenticator>;
+				public getPasswordAuthentication(): java.net.PasswordAuthentication;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export class QueuedThreadPoolExecutor {
+				public static class: java.lang.Class<io.sentry.transport.QueuedThreadPoolExecutor>;
+				public afterExecute(param0: java.lang.Runnable, param1: java.lang.Throwable): void;
+				public submit(param0: java.lang.Runnable): java.util.concurrent.Future<any>;
+				public constructor(param0: number, param1: number, param2: java.util.concurrent.ThreadFactory, param3: java.util.concurrent.RejectedExecutionHandler, param4: io.sentry.ILogger);
+			}
+			export module QueuedThreadPoolExecutor {
+				export class CancelledFuture<T>  extends java.util.concurrent.Future<any> {
+					public static class: java.lang.Class<io.sentry.transport.QueuedThreadPoolExecutor.CancelledFuture<any>>;
+					public get(): any;
+					public isDone(): boolean;
+					public isCancelled(): boolean;
+					public get(param0: number, param1: java.util.concurrent.TimeUnit): any;
+					public cancel(param0: boolean): boolean;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export class RateLimiter {
+				public static class: java.lang.Class<io.sentry.transport.RateLimiter>;
+				public constructor(param0: io.sentry.ILogger);
+				public filter(param0: io.sentry.SentryEnvelope, param1: any): io.sentry.SentryEnvelope;
+				public constructor(param0: io.sentry.transport.ICurrentDateProvider, param1: io.sentry.ILogger);
+				public updateRetryAfterLimits(param0: string, param1: string, param2: number): void;
+			}
+			export module RateLimiter {
+				export class DataCategory {
+					public static class: java.lang.Class<io.sentry.transport.RateLimiter.DataCategory>;
+					public static All: io.sentry.transport.RateLimiter.DataCategory;
+					public static Default: io.sentry.transport.RateLimiter.DataCategory;
+					public static Error: io.sentry.transport.RateLimiter.DataCategory;
+					public static Session: io.sentry.transport.RateLimiter.DataCategory;
+					public static Attachment: io.sentry.transport.RateLimiter.DataCategory;
+					public static Transaction: io.sentry.transport.RateLimiter.DataCategory;
+					public static Security: io.sentry.transport.RateLimiter.DataCategory;
+					public static Unknown: io.sentry.transport.RateLimiter.DataCategory;
+					public getCategory(): string;
+					public static values(): androidNative.Array<io.sentry.transport.RateLimiter.DataCategory>;
+					public static valueOf(param0: string): io.sentry.transport.RateLimiter.DataCategory;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export class ReusableCountLatch {
+				public static class: java.lang.Class<io.sentry.transport.ReusableCountLatch>;
+				public waitTillZero(param0: number, param1: java.util.concurrent.TimeUnit): boolean;
+				public increment(): void;
+				public constructor(param0: number);
+				public getCount(): number;
+				public decrement(): void;
+				public constructor();
+				public waitTillZero(): void;
+			}
+			export module ReusableCountLatch {
+				export class Sync {
+					public static class: java.lang.Class<io.sentry.transport.ReusableCountLatch.Sync>;
+					public tryAcquireShared(param0: number): number;
+					public tryReleaseShared(param0: number): boolean;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export class StdoutTransport extends io.sentry.transport.ITransport {
+				public static class: java.lang.Class<io.sentry.transport.StdoutTransport>;
+				public close(): void;
+				public send(param0: io.sentry.SentryEnvelope, param1: any): void;
+				public send(param0: io.sentry.SentryEnvelope): void;
+				public constructor(param0: io.sentry.ISerializer);
+				public flush(param0: number): void;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module transport {
+			export abstract class TransportResult {
+				public static class: java.lang.Class<io.sentry.transport.TransportResult>;
+				public static success(): io.sentry.transport.TransportResult;
+				public getResponseCode(): number;
+				public isSuccess(): boolean;
+				public static error(): io.sentry.transport.TransportResult;
+				public static error(param0: number): io.sentry.transport.TransportResult;
+			}
+			export module TransportResult {
+				export class ErrorTransportResult extends io.sentry.transport.TransportResult {
+					public static class: java.lang.Class<io.sentry.transport.TransportResult.ErrorTransportResult>;
+					public getResponseCode(): number;
+					public isSuccess(): boolean;
+				}
+				export class SuccessTransportResult extends io.sentry.transport.TransportResult {
+					public static class: java.lang.Class<io.sentry.transport.TransportResult.SuccessTransportResult>;
+					public getResponseCode(): number;
+					public isSuccess(): boolean;
+				}
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module util {
+			export class ApplyScopeUtils {
+				public static class: java.lang.Class<io.sentry.util.ApplyScopeUtils>;
+				public static shouldApplyScopeData(param0: any): boolean;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module util {
+			export class CollectionUtils {
+				public static class: java.lang.Class<io.sentry.util.CollectionUtils>;
+				public static size(param0: java.lang.Iterable<any>): number;
+				public static shallowCopy(param0: java.util.Map): java.util.Map;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module util {
+			export class LogUtils {
+				public static class: java.lang.Class<io.sentry.util.LogUtils>;
+				public static logIfNotRetryable(param0: io.sentry.ILogger, param1: any): void;
+				public static logIfNotFlushable(param0: io.sentry.ILogger, param1: any): void;
+				public constructor();
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module util {
+			export class Objects {
+				public static class: java.lang.Class<io.sentry.util.Objects>;
+				public static requireNonNull(param0: any, param1: string): any;
+			}
+		}
+	}
+}
+
+declare module io {
+	export module sentry {
+		export module util {
+			export class StringUtils {
+				public static class: java.lang.Class<io.sentry.util.StringUtils>;
+				public static capitalize(param0: string): string;
+				public static getStringAfterDot(param0: string): string;
+				public static removeSurrounding(param0: string, param1: string): string;
+			}
+		}
+	}
 }
 
 //Generics information:
-//io.sentry.core.CircularFifoQueue:1
-//io.sentry.core.OptionsContainer:1
-//io.sentry.core.Sentry.OptionsConfiguration:1
-//io.sentry.core.SentryValues:1
-//io.sentry.core.SynchronizedCollection:1
-//io.sentry.core.SynchronizedQueue:1
-//io.sentry.core.transport.RetryingThreadPoolExecutor.AttemptedRunnable:1
-//io.sentry.core.transport.RetryingThreadPoolExecutor.CancelledFuture:1
+//io.sentry.CircularFifoQueue:1
+//io.sentry.OptionsContainer:1
+//io.sentry.Sentry.OptionsConfiguration:1
+//io.sentry.SentryValues:1
+//io.sentry.SynchronizedCollection:1
+//io.sentry.SynchronizedQueue:1
+//io.sentry.UnknownPropertiesTypeAdapterFactory.UnknownPropertiesTypeAdapter:1
+//io.sentry.transport.QueuedThreadPoolExecutor.CancelledFuture:1
+

--- a/src/typings/sentry-api.ios.d.ts
+++ b/src/typings/sentry-api.ios.d.ts
@@ -1,1888 +1,1447 @@
+
 declare function NSErrorFromSentryError(error: SentryError, description: string): NSError;
 
-declare class SentryAsynchronousOperation extends NSOperation {
-  static alloc(): SentryAsynchronousOperation; // inherited from NSObject
+declare class SentryAttachment extends NSObject {
 
-  static new(): SentryAsynchronousOperation; // inherited from NSObject
+	static alloc(): SentryAttachment; // inherited from NSObject
 
-  completeOperation(): void;
+	static new(): SentryAttachment; // inherited from NSObject
+
+	readonly contentType: string;
+
+	readonly data: NSData;
+
+	readonly filename: string;
+
+	readonly path: string;
+
+	constructor(o: { data: NSData; filename: string; });
+
+	constructor(o: { data: NSData; filename: string; contentType: string; });
+
+	constructor(o: { path: string; });
+
+	constructor(o: { path: string; filename: string; });
+
+	constructor(o: { path: string; filename: string; contentType: string; });
+
+	initWithDataFilename(data: NSData, filename: string): this;
+
+	initWithDataFilenameContentType(data: NSData, filename: string, contentType: string): this;
+
+	initWithPath(path: string): this;
+
+	initWithPathFilename(path: string, filename: string): this;
+
+	initWithPathFilenameContentType(path: string, filename: string, contentType: string): this;
 }
 
 declare class SentryBreadcrumb extends NSObject implements SentrySerializable {
-  static alloc(): SentryBreadcrumb; // inherited from NSObject
 
-  static new(): SentryBreadcrumb; // inherited from NSObject
+	static alloc(): SentryBreadcrumb; // inherited from NSObject
 
-  category: string;
+	static new(): SentryBreadcrumb; // inherited from NSObject
 
-  data: NSDictionary<string, any>;
+	category: string;
 
-  level: SentrySeverity;
+	data: NSDictionary<string, any>;
 
-  message: string;
+	level: SentryLevel;
 
-  timestamp: Date;
+	message: string;
 
-  type: string;
+	timestamp: Date;
 
-  readonly debugDescription: string; // inherited from NSObjectProtocol
+	type: string;
 
-  readonly description: string; // inherited from NSObjectProtocol
+	readonly debugDescription: string; // inherited from NSObjectProtocol
 
-  readonly hash: number; // inherited from NSObjectProtocol
+	readonly description: string; // inherited from NSObjectProtocol
 
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
+	readonly hash: number; // inherited from NSObjectProtocol
 
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
+	readonly isProxy: boolean; // inherited from NSObjectProtocol
 
-  readonly; // inherited from NSObjectProtocol
+	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
 
-  constructor(o: { level: SentrySeverity; category: string; });
+	readonly  // inherited from NSObjectProtocol
 
-  class(): typeof NSObject;
+	constructor(o: { level: SentryLevel; category: string; });
 
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
+	class(): typeof NSObject;
 
-  initWithLevelCategory(level: SentrySeverity, category: string): this;
+	conformsToProtocol(aProtocol: any /* Protocol */): boolean;
 
-  isEqual(object: any): boolean;
+	hash(): number;
 
-  isKindOfClass(aClass: typeof NSObject): boolean;
+	initWithLevelCategory(level: SentryLevel, category: string): this;
 
-  isMemberOfClass(aClass: typeof NSObject): boolean;
+	isEqual(object: any): boolean;
 
-  performSelector(aSelector: string): any;
+	isEqualToBreadcrumb(breadcrumb: SentryBreadcrumb): boolean;
 
-  performSelectorWithObject(aSelector: string, object: any): any;
+	isKindOfClass(aClass: typeof NSObject): boolean;
 
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
+	isMemberOfClass(aClass: typeof NSObject): boolean;
 
-  respondsToSelector(aSelector: string): boolean;
+	performSelector(aSelector: string): any;
 
-  retainCount(): number;
+	performSelectorWithObject(aSelector: string, object: any): any;
 
-  self(): this;
+	performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
 
-  serialize(): NSDictionary<string, any>;
-}
+	respondsToSelector(aSelector: string): boolean;
 
-declare class SentryBreadcrumbStore extends NSObject implements SentrySerializable {
-  static alloc(): SentryBreadcrumbStore; // inherited from NSObject
+	retainCount(): number;
 
-  static new(): SentryBreadcrumbStore; // inherited from NSObject
+	self(): this;
 
-  maxBreadcrumbs: number;
-
-  readonly debugDescription: string; // inherited from NSObjectProtocol
-
-  readonly description: string; // inherited from NSObjectProtocol
-
-  readonly hash: number; // inherited from NSObjectProtocol
-
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
-
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
-
-  readonly; // inherited from NSObjectProtocol
-
-  constructor(o: { fileManager: SentryFileManager; });
-
-  addBreadcrumb(crumb: SentryBreadcrumb): void;
-
-  class(): typeof NSObject;
-
-  clear(): void;
-
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
-
-  count(): number;
-
-  initWithFileManager(fileManager: SentryFileManager): this;
-
-  isEqual(object: any): boolean;
-
-  isKindOfClass(aClass: typeof NSObject): boolean;
-
-  isMemberOfClass(aClass: typeof NSObject): boolean;
-
-  performSelector(aSelector: string): any;
-
-  performSelectorWithObject(aSelector: string, object: any): any;
-
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
-
-  respondsToSelector(aSelector: string): boolean;
-
-  retainCount(): number;
-
-  self(): this;
-
-  serialize(): NSDictionary<string, any>;
-}
-
-declare class SentryBreadcrumbTracker extends NSObject {
-  static alloc(): SentryBreadcrumbTracker; // inherited from NSObject
-
-  static new(): SentryBreadcrumbTracker; // inherited from NSObject
-
-  start(): void;
+	serialize(): NSDictionary<string, any>;
 }
 
 declare class SentryClient extends NSObject {
-  static alloc(): SentryClient; // inherited from NSObject
 
-  static new(): SentryClient; // inherited from NSObject
+	static alloc(): SentryClient; // inherited from NSObject
 
-  _debugMeta: NSArray<SentryDebugMeta>;
+	static new(): SentryClient; // inherited from NSObject
 
-  _snapshotThreads: NSArray<SentryThread>;
+	options: SentryOptions;
 
-  beforeSendRequest: (p1: SentryNSURLRequest) => void;
+	constructor(o: { options: SentryOptions; });
 
-  beforeSerializeEvent: (p1: SentryEvent) => void;
+	captureEnvelope(envelope: SentryEnvelope): void;
 
-  breadcrumbs: SentryBreadcrumbStore;
+	captureError(error: NSError): SentryId;
 
-  dist: string;
+	captureErrorWithScope(error: NSError, scope: SentryScope): SentryId;
 
-  enabled: number;
+	captureEvent(event: SentryEvent): SentryId;
 
-  environment: string;
+	captureEventWithScope(event: SentryEvent, scope: SentryScope): SentryId;
 
-  extra: NSDictionary<string, any>;
+	captureException(exception: NSException): SentryId;
 
-  lastContext: NSDictionary<string, any>;
+	captureExceptionWithScope(exception: NSException, scope: SentryScope): SentryId;
 
-  lastEvent: SentryEvent;
+	captureMessage(message: string): SentryId;
 
-  maxBreadcrumbs: number;
+	captureMessageWithScope(message: string, scope: SentryScope): SentryId;
 
-  maxEvents: number;
+	captureSession(session: SentrySession): void;
 
-  releaseName: string;
+	captureUserFeedback(userFeedback: SentryUserFeedback): void;
 
-  sampleRate: number;
+	initWithOptions(options: SentryOptions): this;
 
-  shouldQueueEvent: (p1: SentryEvent, p2: NSHTTPURLResponse, p3: NSError) => boolean;
-
-  shouldSendEvent: (p1: SentryEvent) => boolean;
-
-  tags: NSDictionary<string, string>;
-
-  user: SentryUser;
-
-  static logLevel: SentryLogLevel;
-
-  static readonly sdkName: string;
-
-  static sharedClient: SentryClient;
-
-  static readonly versionString: string;
-
-  constructor(o: { dsn: string; });
-
-  constructor(o: { options: NSDictionary<string, any>; });
-
-  appendStacktraceToEvent(event: SentryEvent): void;
-
-  clearContext(): void;
-
-  crash(): void;
-
-  crashedLastLaunch(): boolean;
-
-  enableAutomaticBreadcrumbTracking(): void;
-
-  initWithDsnDidFailWithError(dsn: string): this;
-
-  initWithOptionsDidFailWithError(options: NSDictionary<string, any>): this;
-
-  reportUserExceptionReasonLanguageLineOfCodeStackTraceLogAllThreadsTerminateProgram(name: string, reason: string, language: string, lineOfCode: string, stackTrace: NSArray<any> | any[], logAllThreads: boolean, terminateProgram: boolean): void;
-
-  sendEventWithCompletionHandler(event: SentryEvent, completionHandler: (p1: NSError) => void): void;
-
-  snapshotStacktrace(snapshotCompleted: () => void): void;
-
-  startCrashHandlerWithError(): boolean;
-
-  storeEvent(event: SentryEvent): void;
-
-  trackMemoryPressureAsEvent(): void;
-}
-
-declare class SentryContext extends NSObject implements SentrySerializable {
-
-  static alloc(): SentryContext; // inherited from NSObject
-
-  static new(): SentryContext; // inherited from NSObject
-
-  appContext: NSDictionary<string, any>;
-
-  deviceContext: NSDictionary<string, any>;
-
-  osContext: NSDictionary<string, any>;
-  otherContexts: NSDictionary<string, any>;
-
-  readonly debugDescription: string; // inherited from NSObjectProtocol
-
-  readonly description: string; // inherited from NSObjectProtocol
-
-  readonly hash: number; // inherited from NSObjectProtocol
-
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
-
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
-
-  readonly  // inherited from NSObjectProtocol
-
-  class(): typeof NSObject;
-
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
-
-  isEqual(object: any): boolean;
-
-  isKindOfClass(aClass: typeof NSObject): boolean;
-
-  isMemberOfClass(aClass: typeof NSObject): boolean;
-
-  performSelector(aSelector: string): any;
-
-  performSelectorWithObject(aSelector: string, object: any): any;
-
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
-
-  respondsToSelector(aSelector: string): boolean;
-
-  retainCount(): number;
-
-  self(): this;
-
-  serialize(): NSDictionary<string, any>;
-}
-
-declare class SentryCrash extends NSObject {
-
-  static alloc(): SentryCrash; // inherited from NSObject
-
-  static new(): SentryCrash; // inherited from NSObject
-
-  static sharedInstance(): SentryCrash;
-
-  readonly activeDurationSinceLastCrash: number;
-
-  readonly activeDurationSinceLaunch: number;
-
-  addConsoleLogToReport: boolean;
-
-  readonly backgroundDurationSinceLastCrash: number;
-
-  readonly backgroundDurationSinceLaunch: number;
-
-  catchZombies: boolean;
-
-  readonly crashedLastLaunch: boolean;
-
-  currentSnapshotUserReportedExceptionHandler: interop.Pointer | interop.Reference<interop.FunctionReference<(p1: NSException) => void>>;
-
-  deadlockWatchdogInterval: number;
-
-  deleteBehaviorAfterSendAll: SentryCrashCDeleteBehavior;
-
-  demangleLanguages: SentryCrashDemangleLanguage;
-
-  doNotIntrospectClasses: NSArray<any>;
-
-  introspectMemory: boolean;
-
-  readonly launchesSinceLastCrash: number;
-
-  maxReportCount: number;
-
-  monitoring: SentryCrashMonitorType;
-
-  onCrash: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>) => void>;
-
-  printPreviousLog: boolean;
-
-  readonly reportCount: number;
-
-  readonly sessionsSinceLastCrash: number;
-
-  readonly sessionsSinceLaunch: number;
-
-  sink: SentryCrashReportFilter;
-
-  readonly systemInfo: NSDictionary<any, any>;
-
-  uncaughtExceptionHandler: interop.Pointer | interop.Reference<interop.FunctionReference<(p1: NSException) => void>>;
-
-  userInfo: NSDictionary<any, any>;
-
-  constructor(o: { basePath: string; });
-
-  deleteAllReports(): void;
-
-  deleteReportWithID(reportID: number): void;
-
-  initWithBasePath(basePath: string): this;
-
-  install(): boolean;
-
-  reportIDs(): NSArray<any>;
-
-  reportUserExceptionReasonLanguageLineOfCodeStackTraceLogAllThreadsTerminateProgram(name: string, reason: string, language: string, lineOfCode: string, stackTrace: NSArray<any> | any[], logAllThreads: boolean, terminateProgram: boolean): void;
-
-  reportWithID(reportID: number): NSDictionary<any, any>;
-
-  sendAllReportsWithCompletion(onCompletion: (p1: NSArray<any>, p2: boolean, p3: NSError) => void): void;
-}
-
-interface SentryCrashBinaryImage {
-  address: number;
-  vmAddress: number;
-  size: number;
-  name: string;
-  uuid: string;
-  cpuType: number;
-  cpuSubType: number;
-  majorVersion: number;
-  minorVersion: number;
-  revisionVersion: number;
-}
-declare var SentryCrashBinaryImage: interop.StructType<SentryCrashBinaryImage>;
-
-interface SentryCrashBufferedReader {
-  buffer: string;
-  bufferLength: number;
-  dataStartPos: number;
-  dataEndPos: number;
-  fd: number;
-}
-declare var SentryCrashBufferedReader: interop.StructType<SentryCrashBufferedReader>;
-
-interface SentryCrashBufferedWriter {
-  buffer: string;
-  bufferLength: number;
-  position: number;
-  fd: number;
-}
-declare var SentryCrashBufferedWriter: interop.StructType<SentryCrashBufferedWriter>;
-
-declare const enum SentryCrashCDeleteBehavior {
-
-  Never = 0,
-
-  OnSucess = 1,
-
-  Always = 2
-}
-
-declare class SentryCrashCString extends NSObject {
-
-  static alloc(): SentryCrashCString; // inherited from NSObject
-
-  static new(): SentryCrashCString; // inherited from NSObject
-
-  static stringWithCString(string: string | interop.Pointer | interop.Reference<any>): SentryCrashCString;
-
-  static stringWithData(data: NSData): SentryCrashCString;
-
-  static stringWithDataLength(data: string | interop.Pointer | interop.Reference<any>, length: number): SentryCrashCString;
-
-  static stringWithString(string: string): SentryCrashCString;
-
-  readonly bytes: string;
-
-  readonly length: number;
-
-  constructor(o: { CString: string | interop.Pointer | interop.Reference<any>; });
-
-  constructor(o: { data: NSData; });
-
-  constructor(o: { data: string | interop.Pointer | interop.Reference<any>; length: number; });
-
-  constructor(o: { string: string; });
-
-  initWithCString(string: string | interop.Pointer | interop.Reference<any>): this;
-
-  initWithData(data: NSData): this;
-
-  initWithDataLength(data: string | interop.Pointer | interop.Reference<any>, length: number): this;
-
-  initWithString(string: string): this;
-}
-
-declare const enum SentryCrashDemangleLanguage {
-
-  None = 0,
-
-  CPlusPlus = 1,
-
-  Swift = 2,
-
-  All = -2
-}
-
-declare class SentryCrashDoctor extends NSObject {
-
-  static alloc(): SentryCrashDoctor; // inherited from NSObject
-
-  static doctor(): SentryCrashDoctor;
-
-  static new(): SentryCrashDoctor; // inherited from NSObject
-
-  diagnoseCrash(crashReport: NSDictionary<any, any>): string;
+	storeEnvelope(envelope: SentryEnvelope): void;
 }
 
 declare class SentryCrashExceptionApplication extends NSObject {
 
-  static alloc(): SentryCrashExceptionApplication; // inherited from NSObject
+	static alloc(): SentryCrashExceptionApplication; // inherited from NSObject
 
-  static new(): SentryCrashExceptionApplication; // inherited from NSObject
+	static new(): SentryCrashExceptionApplication; // inherited from NSObject
 }
-
-declare var SentryCrashFrameworkVersionNumber: number;
-
-declare var SentryCrashFrameworkVersionString: interop.Reference<number>;
-
-declare class SentryCrashInstallation extends NSObject {
-
-  static alloc(): SentryCrashInstallation; // inherited from NSObject
-
-  static new(): SentryCrashInstallation; // inherited from NSObject
-
-  onCrash: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>) => void>;
-
-  constructor(o: { requiredProperties: NSArray<any> | any[]; });
-
-  addPreFilter(filter: SentryCrashReportFilter): void;
-
-  initWithRequiredProperties(requiredProperties: NSArray<any> | any[]): this;
-
-  install(): void;
-
-  makeKeyPath(keyPath: string): string;
-
-  makeKeyPaths(keyPaths: NSArray<any> | any[]): NSArray<any>;
-
-  reportFieldForPropertySetKey(propertyName: string, key: any): void;
-
-  reportFieldForPropertySetValue(propertyName: string, value: any): void;
-
-  sendAllReportsWithCompletion(onCompletion: (p1: NSArray<any>, p2: boolean, p3: NSError) => void): void;
-
-  sink(): SentryCrashReportFilter;
-}
-
-declare class SentryCrashJSONCodec extends NSObject {
-
-  static alloc(): SentryCrashJSONCodec; // inherited from NSObject
-
-  static decodeOptionsError(JSONData: NSData, options: SentryCrashJSONDecodeOption): any;
-
-  static encodeOptionsError(object: any, options: SentryCrashJSONEncodeOption): NSData;
-
-  static new(): SentryCrashJSONCodec; // inherited from NSObject
-}
-
-interface SentryCrashJSONDecodeCallbacks {
-  onBooleanElement: interop.FunctionReference<(p1: string, p2: boolean, p3: interop.Pointer | interop.Reference<any>) => number>;
-  onFloatingPointElement: interop.FunctionReference<(p1: string, p2: number, p3: interop.Pointer | interop.Reference<any>) => number>;
-  onIntegerElement: interop.FunctionReference<(p1: string, p2: number, p3: interop.Pointer | interop.Reference<any>) => number>;
-  onNullElement: interop.FunctionReference<(p1: string, p2: interop.Pointer | interop.Reference<any>) => number>;
-  onStringElement: interop.FunctionReference<(p1: string, p2: string, p3: interop.Pointer | interop.Reference<any>) => number>;
-  onBeginObject: interop.FunctionReference<(p1: string, p2: interop.Pointer | interop.Reference<any>) => number>;
-  onBeginArray: interop.FunctionReference<(p1: string, p2: interop.Pointer | interop.Reference<any>) => number>;
-  onEndContainer: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<any>) => number>;
-  onEndData: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<any>) => number>;
-}
-declare var SentryCrashJSONDecodeCallbacks: interop.StructType<SentryCrashJSONDecodeCallbacks>;
-
-declare const enum SentryCrashJSONDecodeOption {
-
-  None = 0,
-
-  IgnoreNullInArray = 1,
-
-  IgnoreNullInObject = 2,
-
-  IgnoreAllNulls = 3,
-
-  KeepPartialObject = 4
-}
-
-interface SentryCrashJSONEncodeContext {
-  addJSONData: interop.FunctionReference<(p1: string, p2: number, p3: interop.Pointer | interop.Reference<any>) => number>;
-  userData: interop.Pointer | interop.Reference<any>;
-  containerLevel: number;
-  isObject: interop.Reference<boolean>;
-  containerFirstEntry: boolean;
-  prettyPrint: boolean;
-}
-declare var SentryCrashJSONEncodeContext: interop.StructType<SentryCrashJSONEncodeContext>;
-
-declare const enum SentryCrashJSONEncodeOption {
-
-  None = 0,
-
-  Pretty = 1,
-
-  Sorted = 2
-}
-
-declare const SentryCrashJSON_ERROR_CANNOT_ADD_DATA: number;
-
-declare const SentryCrashJSON_ERROR_DATA_TOO_LONG: number;
-
-declare const SentryCrashJSON_ERROR_INCOMPLETE: number;
-
-declare const SentryCrashJSON_ERROR_INVALID_CHARACTER: number;
-
-declare const SentryCrashJSON_ERROR_INVALID_DATA: number;
-
-declare const SentryCrashJSON_OK: number;
-
-declare const enum SentryCrashMonitorType {
-
-  MachException = 1,
-
-  Signal = 2,
-
-  CPPException = 4,
-
-  NSException = 8,
-
-  MainThreadDeadlock = 16,
-
-  UserReported = 32,
-
-  System = 64,
-
-  ApplicationState = 128,
-
-  Zombie = 256
-}
-
-declare const enum SentryCrashObjCClassType {
-
-  Unknown = 0,
-
-  String = 1,
-
-  Date = 2,
-
-  URL = 3,
-
-  Array = 4,
-
-  Dictionary = 5,
-
-  Number = 6,
-
-  Exception = 7
-}
-
-interface SentryCrashObjCIvar {
-  name: string;
-  type: string;
-  index: number;
-}
-declare var SentryCrashObjCIvar: interop.StructType<SentryCrashObjCIvar>;
-
-declare const enum SentryCrashObjCType {
-
-  Unknown = 0,
-
-  Class = 1,
-
-  Object = 2,
-
-  Block = 3
-}
-
-declare class SentryCrashReportConverter extends NSObject {
-
-  static alloc(): SentryCrashReportConverter; // inherited from NSObject
-
-  static new(): SentryCrashReportConverter; // inherited from NSObject
-
-  userContext: NSDictionary<any, any>;
-
-  constructor(o: { report: NSDictionary<any, any>; });
-
-  convertReportToEvent(): SentryEvent;
-
-  initWithReport(report: NSDictionary<any, any>): this;
-}
-
-interface SentryCrashReportFilter extends NSObjectProtocol {
-
-  filterReportsOnCompletion(reports: NSArray<any> | any[], onCompletion: (p1: NSArray<any>, p2: boolean, p3: NSError) => void): void;
-}
-declare var SentryCrashReportFilter: {
-
-  prototype: SentryCrashReportFilter;
-};
-
-declare class SentryCrashReportFilterCombine extends NSObject implements SentryCrashReportFilter {
-
-  static alloc(): SentryCrashReportFilterCombine; // inherited from NSObject
-
-  static filterWithFiltersAndKeys(firstFilter: any): SentryCrashReportFilterCombine;
-
-  static new(): SentryCrashReportFilterCombine; // inherited from NSObject
-
-  readonly debugDescription: string; // inherited from NSObjectProtocol
-
-  readonly description: string; // inherited from NSObjectProtocol
-
-  readonly hash: number; // inherited from NSObjectProtocol
-
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
-
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
-
-  readonly  // inherited from NSObjectProtocol
-
-  constructor(o: { filtersAndKeys: any; });
-
-  class(): typeof NSObject;
-
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
-
-  filterReportsOnCompletion(reports: NSArray<any> | any[], onCompletion: (p1: NSArray<any>, p2: boolean, p3: NSError) => void): void;
-
-  initWithFiltersAndKeys(firstFilter: any): this;
-
-  isEqual(object: any): boolean;
-
-  isKindOfClass(aClass: typeof NSObject): boolean;
-
-  isMemberOfClass(aClass: typeof NSObject): boolean;
-
-  performSelector(aSelector: string): any;
-
-  performSelectorWithObject(aSelector: string, object: any): any;
-
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
-
-  respondsToSelector(aSelector: string): boolean;
-
-  retainCount(): number;
-
-  self(): this;
-}
-
-declare class SentryCrashReportFilterConcatenate extends NSObject implements SentryCrashReportFilter {
-
-  static alloc(): SentryCrashReportFilterConcatenate; // inherited from NSObject
-
-  static filterWithSeparatorFmtKeys(separatorFmt: string, firstKey: any): SentryCrashReportFilterConcatenate;
-
-  static new(): SentryCrashReportFilterConcatenate; // inherited from NSObject
-
-  readonly debugDescription: string; // inherited from NSObjectProtocol
-
-  readonly description: string; // inherited from NSObjectProtocol
-
-  readonly hash: number; // inherited from NSObjectProtocol
-
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
-
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
-
-  readonly  // inherited from NSObjectProtocol
-
-  constructor(o: { separatorFmt: string; keys: any; });
-
-  class(): typeof NSObject;
-
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
-
-  filterReportsOnCompletion(reports: NSArray<any> | any[], onCompletion: (p1: NSArray<any>, p2: boolean, p3: NSError) => void): void;
-
-  initWithSeparatorFmtKeys(separatorFmt: string, firstKey: any): this;
-
-  isEqual(object: any): boolean;
-
-  isKindOfClass(aClass: typeof NSObject): boolean;
-
-  isMemberOfClass(aClass: typeof NSObject): boolean;
-
-  performSelector(aSelector: string): any;
-
-  performSelectorWithObject(aSelector: string, object: any): any;
-
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
-
-  respondsToSelector(aSelector: string): boolean;
-
-  retainCount(): number;
-
-  self(): this;
-}
-
-declare class SentryCrashReportFilterDataToString extends NSObject implements SentryCrashReportFilter {
-
-  static alloc(): SentryCrashReportFilterDataToString; // inherited from NSObject
-
-  static filter(): SentryCrashReportFilterDataToString;
-
-  static new(): SentryCrashReportFilterDataToString; // inherited from NSObject
-
-  readonly debugDescription: string; // inherited from NSObjectProtocol
-
-  readonly description: string; // inherited from NSObjectProtocol
-
-  readonly hash: number; // inherited from NSObjectProtocol
-
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
-
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
-
-  readonly  // inherited from NSObjectProtocol
-
-  class(): typeof NSObject;
-
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
-
-  filterReportsOnCompletion(reports: NSArray<any> | any[], onCompletion: (p1: NSArray<any>, p2: boolean, p3: NSError) => void): void;
-
-  isEqual(object: any): boolean;
-
-  isKindOfClass(aClass: typeof NSObject): boolean;
-
-  isMemberOfClass(aClass: typeof NSObject): boolean;
-
-  performSelector(aSelector: string): any;
-
-  performSelectorWithObject(aSelector: string, object: any): any;
-
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
-
-  respondsToSelector(aSelector: string): boolean;
-
-  retainCount(): number;
-
-  self(): this;
-}
-
-declare class SentryCrashReportFilterObjectForKey extends NSObject implements SentryCrashReportFilter {
-
-  static alloc(): SentryCrashReportFilterObjectForKey; // inherited from NSObject
-
-  static filterWithKeyAllowNotFound(key: any, allowNotFound: boolean): SentryCrashReportFilterObjectForKey;
-
-  static new(): SentryCrashReportFilterObjectForKey; // inherited from NSObject
-
-  readonly debugDescription: string; // inherited from NSObjectProtocol
-
-  readonly description: string; // inherited from NSObjectProtocol
-
-  readonly hash: number; // inherited from NSObjectProtocol
-
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
-
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
-
-  readonly  // inherited from NSObjectProtocol
-
-  constructor(o: { key: any; allowNotFound: boolean; });
-
-  class(): typeof NSObject;
-
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
-
-  filterReportsOnCompletion(reports: NSArray<any> | any[], onCompletion: (p1: NSArray<any>, p2: boolean, p3: NSError) => void): void;
-
-  initWithKeyAllowNotFound(key: any, allowNotFound: boolean): this;
-
-  isEqual(object: any): boolean;
-
-  isKindOfClass(aClass: typeof NSObject): boolean;
-
-  isMemberOfClass(aClass: typeof NSObject): boolean;
-
-  performSelector(aSelector: string): any;
-
-  performSelectorWithObject(aSelector: string, object: any): any;
-
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
-
-  respondsToSelector(aSelector: string): boolean;
-
-  retainCount(): number;
-
-  self(): this;
-}
-
-declare class SentryCrashReportFilterPassthrough extends NSObject implements SentryCrashReportFilter {
-
-  static alloc(): SentryCrashReportFilterPassthrough; // inherited from NSObject
-
-  static filter(): SentryCrashReportFilterPassthrough;
-
-  static new(): SentryCrashReportFilterPassthrough; // inherited from NSObject
-
-  readonly debugDescription: string; // inherited from NSObjectProtocol
-
-  readonly description: string; // inherited from NSObjectProtocol
-
-  readonly hash: number; // inherited from NSObjectProtocol
-
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
-
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
-
-  readonly  // inherited from NSObjectProtocol
-
-  class(): typeof NSObject;
-
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
-
-  filterReportsOnCompletion(reports: NSArray<any> | any[], onCompletion: (p1: NSArray<any>, p2: boolean, p3: NSError) => void): void;
-
-  isEqual(object: any): boolean;
-
-  isKindOfClass(aClass: typeof NSObject): boolean;
-
-  isMemberOfClass(aClass: typeof NSObject): boolean;
-
-  performSelector(aSelector: string): any;
-
-  performSelectorWithObject(aSelector: string, object: any): any;
-
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
-
-  respondsToSelector(aSelector: string): boolean;
-
-  retainCount(): number;
-
-  self(): this;
-}
-
-declare class SentryCrashReportFilterPipeline extends NSObject implements SentryCrashReportFilter {
-
-  static alloc(): SentryCrashReportFilterPipeline; // inherited from NSObject
-
-  static filterWithFilters(firstFilter: any): SentryCrashReportFilterPipeline;
-
-  static new(): SentryCrashReportFilterPipeline; // inherited from NSObject
-
-  readonly filters: NSArray<any>;
-
-  readonly debugDescription: string; // inherited from NSObjectProtocol
-
-  readonly description: string; // inherited from NSObjectProtocol
-
-  readonly hash: number; // inherited from NSObjectProtocol
-
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
-
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
-
-  readonly  // inherited from NSObjectProtocol
-
-  constructor(o: { filters: any; });
-
-  addFilter(filter: SentryCrashReportFilter): void;
-
-  class(): typeof NSObject;
-
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
-
-  filterReportsOnCompletion(reports: NSArray<any> | any[], onCompletion: (p1: NSArray<any>, p2: boolean, p3: NSError) => void): void;
-
-  initWithFilters(firstFilter: any): this;
-
-  isEqual(object: any): boolean;
-
-  isKindOfClass(aClass: typeof NSObject): boolean;
-
-  isMemberOfClass(aClass: typeof NSObject): boolean;
-
-  performSelector(aSelector: string): any;
-
-  performSelectorWithObject(aSelector: string, object: any): any;
-
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
-
-  respondsToSelector(aSelector: string): boolean;
-
-  retainCount(): number;
-
-  self(): this;
-}
-
-declare class SentryCrashReportFilterStringToData extends NSObject implements SentryCrashReportFilter {
-
-  static alloc(): SentryCrashReportFilterStringToData; // inherited from NSObject
-
-  static filter(): SentryCrashReportFilterStringToData;
-
-  static new(): SentryCrashReportFilterStringToData; // inherited from NSObject
-
-  readonly debugDescription: string; // inherited from NSObjectProtocol
-
-  readonly description: string; // inherited from NSObjectProtocol
-
-  readonly hash: number; // inherited from NSObjectProtocol
-
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
-
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
-
-  readonly  // inherited from NSObjectProtocol
-
-  class(): typeof NSObject;
-
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
-
-  filterReportsOnCompletion(reports: NSArray<any> | any[], onCompletion: (p1: NSArray<any>, p2: boolean, p3: NSError) => void): void;
-
-  isEqual(object: any): boolean;
-
-  isKindOfClass(aClass: typeof NSObject): boolean;
-
-  isMemberOfClass(aClass: typeof NSObject): boolean;
-
-  performSelector(aSelector: string): any;
-
-  performSelectorWithObject(aSelector: string, object: any): any;
-
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
-
-  respondsToSelector(aSelector: string): boolean;
-
-  retainCount(): number;
-
-  self(): this;
-}
-
-declare class SentryCrashReportFilterSubset extends NSObject implements SentryCrashReportFilter {
-
-  static alloc(): SentryCrashReportFilterSubset; // inherited from NSObject
-
-  static filterWithKeys(firstKeyPath: any): SentryCrashReportFilterSubset;
-
-  static new(): SentryCrashReportFilterSubset; // inherited from NSObject
-
-  readonly debugDescription: string; // inherited from NSObjectProtocol
-
-  readonly description: string; // inherited from NSObjectProtocol
-
-  readonly hash: number; // inherited from NSObjectProtocol
-
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
-
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
-
-  readonly  // inherited from NSObjectProtocol
-
-  constructor(o: { keys: any; });
-
-  class(): typeof NSObject;
-
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
-
-  filterReportsOnCompletion(reports: NSArray<any> | any[], onCompletion: (p1: NSArray<any>, p2: boolean, p3: NSError) => void): void;
-
-  initWithKeys(firstKeyPath: any): this;
-
-  isEqual(object: any): boolean;
-
-  isKindOfClass(aClass: typeof NSObject): boolean;
-
-  isMemberOfClass(aClass: typeof NSObject): boolean;
-
-  performSelector(aSelector: string): any;
-
-  performSelectorWithObject(aSelector: string, object: any): any;
-
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
-
-  respondsToSelector(aSelector: string): boolean;
-
-  retainCount(): number;
-
-  self(): this;
-}
-
-declare class SentryCrashReportSink extends NSObject implements SentryCrashReportFilter {
-
-  static alloc(): SentryCrashReportSink; // inherited from NSObject
-
-  static new(): SentryCrashReportSink; // inherited from NSObject
-
-  readonly debugDescription: string; // inherited from NSObjectProtocol
-
-  readonly description: string; // inherited from NSObjectProtocol
-
-  readonly hash: number; // inherited from NSObjectProtocol
-
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
-
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
-
-  readonly  // inherited from NSObjectProtocol
-
-  class(): typeof NSObject;
-
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
-
-  filterReportsOnCompletion(reports: NSArray<any> | any[], onCompletion: (p1: NSArray<any>, p2: boolean, p3: NSError) => void): void;
-
-  isEqual(object: any): boolean;
-
-  isKindOfClass(aClass: typeof NSObject): boolean;
-
-  isMemberOfClass(aClass: typeof NSObject): boolean;
-
-  performSelector(aSelector: string): any;
-
-  performSelectorWithObject(aSelector: string, object: any): any;
-
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
-
-  respondsToSelector(aSelector: string): boolean;
-
-  retainCount(): number;
-
-  self(): this;
-}
-
-interface SentryCrashReportWriter {
-  addBooleanElement: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>, p2: string, p3: boolean) => void>;
-  addFloatingPointElement: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>, p2: string, p3: number) => void>;
-  addIntegerElement: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>, p2: string, p3: number) => void>;
-  addUIntegerElement: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>, p2: string, p3: number) => void>;
-  addStringElement: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>, p2: string, p3: string) => void>;
-  addTextFileElement: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>, p2: string, p3: string) => void>;
-  addTextFileLinesElement: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>, p2: string, p3: string) => void>;
-  addJSONFileElement: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>, p2: string, p3: string, p4: boolean) => void>;
-  addDataElement: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>, p2: string, p3: string, p4: number) => void>;
-  beginDataElement: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>, p2: string) => void>;
-  appendDataElement: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>, p2: string, p3: number) => void>;
-  endDataElement: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>) => void>;
-  addUUIDElement: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>, p2: string, p3: string) => void>;
-  addJSONElement: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>, p2: string, p3: string, p4: boolean) => void>;
-  beginObject: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>, p2: string) => void>;
-  beginArray: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>, p2: string) => void>;
-  endContainer: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>) => void>;
-  context: interop.Pointer | interop.Reference<any>;
-}
-declare var SentryCrashReportWriter: interop.StructType<SentryCrashReportWriter>;
-
-interface SentryCrashStackCursor {
-  stackEntry: { address: number; imageName: string; imageAddress: number; symbolName: string; symbolAddress: number; };
-  state: { currentDepth: number; hasGivenUp: boolean; };
-  resetCursor: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashStackCursor>) => void>;
-  advanceCursor: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashStackCursor>) => boolean>;
-  symbolicate: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashStackCursor>) => boolean>;
-  context: interop.Reference<interop.Pointer | interop.Reference<any>>;
-}
-declare var SentryCrashStackCursor: interop.StructType<SentryCrashStackCursor>;
-
-interface SentryCrashStackCursor_Backtrace_Context {
-  skippedEntries: number;
-  backtraceLength: number;
-  backtrace: interop.Pointer | interop.Reference<number>;
-}
-declare var SentryCrashStackCursor_Backtrace_Context: interop.StructType<SentryCrashStackCursor_Backtrace_Context>;
-
-interface SentryCrash_AppState {
-  activeDurationSinceLastCrash: number;
-  backgroundDurationSinceLastCrash: number;
-  launchesSinceLastCrash: number;
-  sessionsSinceLastCrash: number;
-  activeDurationSinceLaunch: number;
-  backgroundDurationSinceLaunch: number;
-  sessionsSinceLaunch: number;
-  crashedLastLaunch: boolean;
-  crashedThisLaunch: boolean;
-  appStateTransitionTime: number;
-  applicationIsActive: boolean;
-  applicationIsInForeground: boolean;
-}
-declare var SentryCrash_AppState: interop.StructType<SentryCrash_AppState>;
 
 declare class SentryDebugMeta extends NSObject implements SentrySerializable {
 
-  static alloc(): SentryDebugMeta; // inherited from NSObject
+	static alloc(): SentryDebugMeta; // inherited from NSObject
 
-  static new(): SentryDebugMeta; // inherited from NSObject
+	static new(): SentryDebugMeta; // inherited from NSObject
 
-  cpuSubType: number;
+	imageAddress: string;
 
-  cpuType: number;
+	imageSize: number;
 
-  imageAddress: string;
+	imageVmAddress: string;
 
-  imageSize: number;
+	name: string;
 
-  imageVmAddress: string;
+	type: string;
 
-  majorVersion: number;
+	uuid: string;
 
-  minorVersion: number;
+	readonly debugDescription: string; // inherited from NSObjectProtocol
 
-  name: string;
+	readonly description: string; // inherited from NSObjectProtocol
 
-  revisionVersion: number;
+	readonly hash: number; // inherited from NSObjectProtocol
 
-  type: string;
+	readonly isProxy: boolean; // inherited from NSObjectProtocol
 
-  uuid: string;
+	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
 
-  readonly debugDescription: string; // inherited from NSObjectProtocol
+	readonly  // inherited from NSObjectProtocol
 
-  readonly description: string; // inherited from NSObjectProtocol
+	class(): typeof NSObject;
 
-  readonly hash: number; // inherited from NSObjectProtocol
+	conformsToProtocol(aProtocol: any /* Protocol */): boolean;
 
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
+	isEqual(object: any): boolean;
 
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
+	isKindOfClass(aClass: typeof NSObject): boolean;
 
-  readonly  // inherited from NSObjectProtocol
+	isMemberOfClass(aClass: typeof NSObject): boolean;
 
-  class(): typeof NSObject;
+	performSelector(aSelector: string): any;
 
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
+	performSelectorWithObject(aSelector: string, object: any): any;
 
-  isEqual(object: any): boolean;
+	performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
 
-  isKindOfClass(aClass: typeof NSObject): boolean;
+	respondsToSelector(aSelector: string): boolean;
 
-  isMemberOfClass(aClass: typeof NSObject): boolean;
+	retainCount(): number;
 
-  performSelector(aSelector: string): any;
+	self(): this;
 
-  performSelectorWithObject(aSelector: string, object: any): any;
-
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
-
-  respondsToSelector(aSelector: string): boolean;
-
-  retainCount(): number;
-
-  self(): this;
-
-  serialize(): NSDictionary<string, any>;
+	serialize(): NSDictionary<string, any>;
 }
 
 declare class SentryDsn extends NSObject {
 
-  static alloc(): SentryDsn; // inherited from NSObject
+	static alloc(): SentryDsn; // inherited from NSObject
 
-  static new(): SentryDsn; // inherited from NSObject
+	static new(): SentryDsn; // inherited from NSObject
 
-  url: NSURL;
+	readonly url: NSURL;
 
-  constructor(o: { string: string; });
+	constructor(o: { string: string; });
 
-  getHash(): string;
+	getEnvelopeEndpoint(): NSURL;
 
-  initWithStringDidFailWithError(dsnString: string): this;
+	getHash(): string;
+
+	getStoreEndpoint(): NSURL;
+
+	initWithStringDidFailWithError(dsnString: string): this;
+}
+
+declare class SentryEnvelope extends NSObject {
+
+	static alloc(): SentryEnvelope; // inherited from NSObject
+
+	static new(): SentryEnvelope; // inherited from NSObject
+
+	readonly header: SentryEnvelopeHeader;
+
+	readonly items: NSArray<SentryEnvelopeItem>;
+
+	constructor(o: { event: SentryEvent; });
+
+	constructor(o: { header: SentryEnvelopeHeader; items: NSArray<SentryEnvelopeItem> | SentryEnvelopeItem[]; });
+
+	constructor(o: { header: SentryEnvelopeHeader; singleItem: SentryEnvelopeItem; });
+
+	constructor(o: { id: SentryId; items: NSArray<SentryEnvelopeItem> | SentryEnvelopeItem[]; });
+
+	constructor(o: { id: SentryId; singleItem: SentryEnvelopeItem; });
+
+	constructor(o: { session: SentrySession; });
+
+	constructor(o: { sessions: NSArray<SentrySession> | SentrySession[]; });
+
+	constructor(o: { userFeedback: SentryUserFeedback; });
+
+	initWithEvent(event: SentryEvent): this;
+
+	initWithHeaderItems(header: SentryEnvelopeHeader, items: NSArray<SentryEnvelopeItem> | SentryEnvelopeItem[]): this;
+
+	initWithHeaderSingleItem(header: SentryEnvelopeHeader, item: SentryEnvelopeItem): this;
+
+	initWithIdItems(id: SentryId, items: NSArray<SentryEnvelopeItem> | SentryEnvelopeItem[]): this;
+
+	initWithIdSingleItem(id: SentryId, item: SentryEnvelopeItem): this;
+
+	initWithSession(session: SentrySession): this;
+
+	initWithSessions(sessions: NSArray<SentrySession> | SentrySession[]): this;
+
+	initWithUserFeedback(userFeedback: SentryUserFeedback): this;
+}
+
+declare class SentryEnvelopeHeader extends NSObject {
+
+	static alloc(): SentryEnvelopeHeader; // inherited from NSObject
+
+	static new(): SentryEnvelopeHeader; // inherited from NSObject
+
+	readonly eventId: SentryId;
+
+	readonly sdkInfo: SentrySdkInfo;
+
+	constructor(o: { id: SentryId; });
+
+	constructor(o: { id: SentryId; andSdkInfo: SentrySdkInfo; });
+
+	initWithId(eventId: SentryId): this;
+
+	initWithIdAndSdkInfo(eventId: SentryId, sdkInfo: SentrySdkInfo): this;
+}
+
+declare class SentryEnvelopeItem extends NSObject {
+
+	static alloc(): SentryEnvelopeItem; // inherited from NSObject
+
+	static new(): SentryEnvelopeItem; // inherited from NSObject
+
+	readonly data: NSData;
+
+	readonly header: SentryEnvelopeItemHeader;
+
+	constructor(o: { attachment: SentryAttachment; maxAttachmentSize: number; });
+
+	constructor(o: { event: SentryEvent; });
+
+	constructor(o: { header: SentryEnvelopeItemHeader; data: NSData; });
+
+	constructor(o: { session: SentrySession; });
+
+	constructor(o: { userFeedback: SentryUserFeedback; });
+
+	initWithAttachmentMaxAttachmentSize(attachment: SentryAttachment, maxAttachmentSize: number): this;
+
+	initWithEvent(event: SentryEvent): this;
+
+	initWithHeaderData(header: SentryEnvelopeItemHeader, data: NSData): this;
+
+	initWithSession(session: SentrySession): this;
+
+	initWithUserFeedback(userFeedback: SentryUserFeedback): this;
+}
+
+declare class SentryEnvelopeItemHeader extends NSObject {
+
+	static alloc(): SentryEnvelopeItemHeader; // inherited from NSObject
+
+	static new(): SentryEnvelopeItemHeader; // inherited from NSObject
+
+	readonly contentType: string;
+
+	readonly filename: string;
+
+	readonly length: number;
+
+	readonly type: string;
+
+	constructor(o: { type: string; length: number; });
+
+	constructor(o: { type: string; length: number; filenname: string; contentType: string; });
+
+	initWithTypeLength(type: string, length: number): this;
+
+	initWithTypeLengthFilennameContentType(type: string, length: number, filename: string, contentType: string): this;
 }
 
 declare const enum SentryError {
 
-  kSentryErrorUnknownError = -1,
+	kSentryErrorUnknownError = -1,
 
-  kSentryErrorInvalidDsnError = 100,
+	kSentryErrorInvalidDsnError = 100,
 
-  kSentryErrorSentryCrashNotInstalledError = 101,
+	kSentryErrorSentryCrashNotInstalledError = 101,
 
-  kSentryErrorInvalidCrashReportError = 102,
+	kSentryErrorInvalidCrashReportError = 102,
 
-  kSentryErrorCompressionError = 103,
+	kSentryErrorCompressionError = 103,
 
-  kSentryErrorJsonConversionError = 104,
+	kSentryErrorJsonConversionError = 104,
 
-  kSentryErrorCouldNotFindDirectory = 105,
+	kSentryErrorCouldNotFindDirectory = 105,
 
-  kSentryErrorRequestError = 106,
+	kSentryErrorRequestError = 106,
 
-  kSentryErrorEventNotSent = 107
+	kSentryErrorEventNotSent = 107
 }
 
 declare var SentryErrorDomain: string;
 
 declare class SentryEvent extends NSObject implements SentrySerializable {
 
-  static alloc(): SentryEvent; // inherited from NSObject
+	static alloc(): SentryEvent; // inherited from NSObject
 
-  static new(): SentryEvent; // inherited from NSObject
+	static new(): SentryEvent; // inherited from NSObject
 
-  breadcrumbsSerialized: NSDictionary<string, any>;
+	breadcrumbs: NSArray<SentryBreadcrumb>;
 
-  context: SentryContext;
+	context: NSDictionary<string, NSDictionary<string, any>>;
 
-  debugMeta: NSArray<SentryDebugMeta>;
+	debugMeta: NSArray<SentryDebugMeta>;
 
-  dist: string;
+	dist: string;
 
-  environment: string;
+	environment: string;
 
-  eventId: string;
+	error: NSError;
 
-  exceptions: NSArray<SentryException>;
+	eventId: SentryId;
 
-  extra: NSDictionary<string, any>;
+	exceptions: NSArray<SentryException>;
 
-  fingerprint: NSArray<string>;
+	extra: NSDictionary<string, any>;
 
-  infoDict: NSDictionary<any, any>;
+	fingerprint: NSArray<string>;
 
-  json: NSData;
+	level: SentryLevel;
 
-  level: SentrySeverity;
+	logger: string;
 
-  logger: string;
+	message: SentryMessage;
 
-  message: string;
+	modules: NSDictionary<string, string>;
 
-  modules: NSDictionary<string, string>;
+	platform: string;
 
-  platform: string;
+	releaseName: string;
 
-  releaseName: string;
+	sdk: NSDictionary<string, any>;
 
-  sdk: NSDictionary<string, any>;
+	serverName: string;
 
-  serverName: string;
+	stacktrace: SentryStacktrace;
 
-  stacktrace: SentryStacktrace;
+	startTimestamp: Date;
 
-  startTimestamp: Date;
+	tags: NSDictionary<string, string>;
 
-  tags: NSDictionary<string, string>;
+	threads: NSArray<SentryThread>;
 
-  threads: NSArray<SentryThread>;
+	timestamp: Date;
 
-  timestamp: Date;
+	transaction: string;
 
-  transaction: string;
+	type: string;
 
-  type: string;
+	user: SentryUser;
 
-  user: SentryUser;
+	readonly debugDescription: string; // inherited from NSObjectProtocol
 
-  readonly debugDescription: string; // inherited from NSObjectProtocol
+	readonly description: string; // inherited from NSObjectProtocol
 
-  readonly description: string; // inherited from NSObjectProtocol
+	readonly hash: number; // inherited from NSObjectProtocol
 
-  readonly hash: number; // inherited from NSObjectProtocol
+	readonly isProxy: boolean; // inherited from NSObjectProtocol
 
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
+	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
 
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
+	readonly  // inherited from NSObjectProtocol
 
-  readonly  // inherited from NSObjectProtocol
+	constructor(o: { error: NSError; });
 
-  constructor(o: { JSON: NSData; });
+	constructor(o: { level: SentryLevel; });
 
-  constructor(o: { level: SentrySeverity; });
+	class(): typeof NSObject;
 
-  class(): typeof NSObject;
+	conformsToProtocol(aProtocol: any /* Protocol */): boolean;
 
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
+	initWithError(error: NSError): this;
 
-  initWithJSON(json: NSData): this;
+	initWithLevel(level: SentryLevel): this;
 
-  initWithLevel(level: SentrySeverity): this;
+	isEqual(object: any): boolean;
 
-  isEqual(object: any): boolean;
+	isKindOfClass(aClass: typeof NSObject): boolean;
 
-  isKindOfClass(aClass: typeof NSObject): boolean;
+	isMemberOfClass(aClass: typeof NSObject): boolean;
 
-  isMemberOfClass(aClass: typeof NSObject): boolean;
+	performSelector(aSelector: string): any;
 
-  performSelector(aSelector: string): any;
+	performSelectorWithObject(aSelector: string, object: any): any;
 
-  performSelectorWithObject(aSelector: string, object: any): any;
+	performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
 
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
+	respondsToSelector(aSelector: string): boolean;
 
-  respondsToSelector(aSelector: string): boolean;
+	retainCount(): number;
 
-  retainCount(): number;
+	self(): this;
 
-  self(): this;
-
-  serialize(): NSDictionary<string, any>;
+	serialize(): NSDictionary<string, any>;
 }
 
 declare class SentryException extends NSObject implements SentrySerializable {
 
-  static alloc(): SentryException; // inherited from NSObject
+	static alloc(): SentryException; // inherited from NSObject
 
-  static new(): SentryException; // inherited from NSObject
+	static new(): SentryException; // inherited from NSObject
 
-  mechanism: SentryMechanism;
+	mechanism: SentryMechanism;
 
-  module: string;
+	module: string;
 
-  thread: SentryThread;
+	thread: SentryThread;
 
-  type: string;
+	type: string;
 
-  userReported: number;
+	userReported: number;
 
-  value: string;
+	value: string;
 
-  readonly debugDescription: string; // inherited from NSObjectProtocol
+	readonly debugDescription: string; // inherited from NSObjectProtocol
 
-  readonly description: string; // inherited from NSObjectProtocol
+	readonly description: string; // inherited from NSObjectProtocol
 
-  readonly hash: number; // inherited from NSObjectProtocol
+	readonly hash: number; // inherited from NSObjectProtocol
 
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
+	readonly isProxy: boolean; // inherited from NSObjectProtocol
 
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
+	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
 
-  readonly  // inherited from NSObjectProtocol
+	readonly  // inherited from NSObjectProtocol
 
-  constructor(o: { value: string; type: string; });
+	constructor(o: { value: string; type: string; });
 
-  class(): typeof NSObject;
+	class(): typeof NSObject;
 
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
+	conformsToProtocol(aProtocol: any /* Protocol */): boolean;
 
-  initWithValueType(value: string, type: string): this;
+	initWithValueType(value: string, type: string): this;
 
-  isEqual(object: any): boolean;
+	isEqual(object: any): boolean;
 
-  isKindOfClass(aClass: typeof NSObject): boolean;
+	isKindOfClass(aClass: typeof NSObject): boolean;
 
-  isMemberOfClass(aClass: typeof NSObject): boolean;
+	isMemberOfClass(aClass: typeof NSObject): boolean;
 
-  performSelector(aSelector: string): any;
+	performSelector(aSelector: string): any;
 
-  performSelectorWithObject(aSelector: string, object: any): any;
+	performSelectorWithObject(aSelector: string, object: any): any;
 
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
+	performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
 
-  respondsToSelector(aSelector: string): boolean;
+	respondsToSelector(aSelector: string): boolean;
 
-  retainCount(): number;
+	retainCount(): number;
 
-  self(): this;
+	self(): this;
 
-  serialize(): NSDictionary<string, any>;
-}
-
-declare class SentryFileManager extends NSObject {
-
-  static alloc(): SentryFileManager; // inherited from NSObject
-
-  static createDirectoryAtPathWithError(path: string): boolean;
-
-  static new(): SentryFileManager; // inherited from NSObject
-
-  maxBreadcrumbs: number;
-
-  maxEvents: number;
-
-  constructor(o: { dsn: SentryDsn; });
-
-  allFilesInFolder(path: string): NSArray<string>;
-
-  deleteAllFolders(): void;
-
-  deleteAllStoredBreadcrumbs(): void;
-
-  deleteAllStoredEvents(): void;
-
-  getAllStoredBreadcrumbs(): NSArray<NSDictionary<string, any>>;
-
-  getAllStoredEvents(): NSArray<NSDictionary<string, any>>;
-
-  initWithDsnDidFailWithError(dsn: SentryDsn): this;
-
-  removeFileAtPath(path: string): boolean;
-
-  storeBreadcrumb(crumb: SentryBreadcrumb): string;
-
-  storeBreadcrumbMaxCount(crumb: SentryBreadcrumb, maxCount: number): string;
-
-  storeDictionaryToPath(dictionary: NSDictionary<any, any>, path: string): string;
-
-  storeEvent(event: SentryEvent): string;
+	serialize(): NSDictionary<string, any>;
 }
 
 declare class SentryFrame extends NSObject implements SentrySerializable {
 
-  static alloc(): SentryFrame; // inherited from NSObject
+	static alloc(): SentryFrame; // inherited from NSObject
 
-  static new(): SentryFrame; // inherited from NSObject
+	static new(): SentryFrame; // inherited from NSObject
 
-  columnNumber: number;
+	columnNumber: number;
 
-  fileName: string;
+	fileName: string;
 
-  function: string;
+	function: string;
 
-  imageAddress: string;
+	imageAddress: string;
 
-  instructionAddress: string;
+	inApp: number;
 
-  lineNumber: number;
+	instructionAddress: string;
 
-  module: string;
+	lineNumber: number;
 
-  package: string;
+	module: string;
 
-  platform: string;
+	package: string;
 
-  symbolAddress: string;
+	platform: string;
 
-  readonly debugDescription: string; // inherited from NSObjectProtocol
+	symbolAddress: string;
 
-  readonly description: string; // inherited from NSObjectProtocol
+	readonly debugDescription: string; // inherited from NSObjectProtocol
 
-  readonly hash: number; // inherited from NSObjectProtocol
+	readonly description: string; // inherited from NSObjectProtocol
 
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
+	readonly hash: number; // inherited from NSObjectProtocol
 
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
+	readonly isProxy: boolean; // inherited from NSObjectProtocol
 
-  readonly  // inherited from NSObjectProtocol
+	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
 
-  class(): typeof NSObject;
+	readonly  // inherited from NSObjectProtocol
 
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
+	class(): typeof NSObject;
 
-  isEqual(object: any): boolean;
+	conformsToProtocol(aProtocol: any /* Protocol */): boolean;
 
-  isKindOfClass(aClass: typeof NSObject): boolean;
+	isEqual(object: any): boolean;
 
-  isMemberOfClass(aClass: typeof NSObject): boolean;
+	isKindOfClass(aClass: typeof NSObject): boolean;
 
-  performSelector(aSelector: string): any;
+	isMemberOfClass(aClass: typeof NSObject): boolean;
 
-  performSelectorWithObject(aSelector: string, object: any): any;
+	performSelector(aSelector: string): any;
 
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
+	performSelectorWithObject(aSelector: string, object: any): any;
 
-  respondsToSelector(aSelector: string): boolean;
+	performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
 
-  retainCount(): number;
+	respondsToSelector(aSelector: string): boolean;
 
-  self(): this;
+	retainCount(): number;
 
-  serialize(): NSDictionary<string, any>;
+	self(): this;
+
+	serialize(): NSDictionary<string, any>;
 }
 
-declare class SentryInstallation extends SentryCrashInstallation {
+declare class SentryHub extends NSObject {
 
-  static alloc(): SentryInstallation; // inherited from NSObject
+	static alloc(): SentryHub; // inherited from NSObject
 
-  static new(): SentryInstallation; // inherited from NSObject
+	static new(): SentryHub; // inherited from NSObject
 
-  sendAllReports(): void;
+	installedIntegrations: NSMutableArray<NSObject>;
+
+	readonly session: SentrySession;
+
+	constructor(o: { client: SentryClient; andScope: SentryScope; });
+
+	addBreadcrumb(crumb: SentryBreadcrumb): void;
+
+	bindClient(client: SentryClient): void;
+
+	captureEnvelope(envelope: SentryEnvelope): void;
+
+	captureError(error: NSError): SentryId;
+
+	captureErrorWithScope(error: NSError, scope: SentryScope): SentryId;
+
+	captureEvent(event: SentryEvent): SentryId;
+
+	captureEventWithScope(event: SentryEvent, scope: SentryScope): SentryId;
+
+	captureException(exception: NSException): SentryId;
+
+	captureExceptionWithScope(exception: NSException, scope: SentryScope): SentryId;
+
+	captureMessage(message: string): SentryId;
+
+	captureMessageWithScope(message: string, scope: SentryScope): SentryId;
+
+	captureUserFeedback(userFeedback: SentryUserFeedback): void;
+
+	closeCachedSessionWithTimestamp(timestamp: Date): void;
+
+	configureScope(callback: (p1: SentryScope) => void): void;
+
+	endSessionWithTimestamp(timestamp: Date): void;
+
+	getClient(): SentryClient;
+
+	getIntegration(integrationName: string): any;
+
+	getScope(): SentryScope;
+
+	initWithClientAndScope(client: SentryClient, scope: SentryScope): this;
+
+	isIntegrationInstalled(integrationClass: typeof NSObject): boolean;
+
+	setUser(user: SentryUser): void;
+
+	startSession(): void;
 }
 
-declare class SentryJavaScriptBridgeHelper extends NSObject {
+declare class SentryId extends NSObject {
 
-  static alloc(): SentryJavaScriptBridgeHelper; // inherited from NSObject
+	static alloc(): SentryId; // inherited from NSObject
 
-  static convertReactNativeStacktrace(stacktrace: NSArray<any> | any[]): NSArray<SentryFrame>;
+	static new(): SentryId; // inherited from NSObject
 
-  static createSentryBreadcrumbFromJavaScriptBreadcrumb(jsonBreadcrumb: NSDictionary<any, any>): SentryBreadcrumb;
+	readonly sentryIdString: string;
 
-  static createSentryEventFromJavaScriptEvent(jsonEvent: NSDictionary<any, any>): SentryEvent;
+	static readonly empty: SentryId;
 
-  static createSentryUserFromJavaScriptUser(user: NSDictionary<any, any>): SentryUser;
+	constructor(o: { UUID: NSUUID; });
 
-  static new(): SentryJavaScriptBridgeHelper; // inherited from NSObject
+	constructor(o: { UUIDString: string; });
 
-  static parseJavaScriptStacktrace(stacktrace: string): NSArray<any>;
+	initWithUUID(uuid: NSUUID): this;
 
-  static sanitizeDictionary(dictionary: NSDictionary<any, any>): NSDictionary<any, any>;
-
-  static sentryLogLevelFromJavaScriptLevel(level: number): SentryLogLevel;
+	initWithUUIDString(string: string): this;
 }
 
-declare class SentryLog extends NSObject {
+interface SentryIntegrationProtocol extends NSObjectProtocol {
 
-  static alloc(): SentryLog; // inherited from NSObject
+	installWithOptions(options: SentryOptions): void;
+}
+declare var SentryIntegrationProtocol: {
 
-  static logWithMessageAndLevel(message: string, level: SentryLogLevel): void;
+	prototype: SentryIntegrationProtocol;
+};
 
-  static new(): SentryLog; // inherited from NSObject
+declare const enum SentryLevel {
+
+	kSentryLevelNone = 0,
+
+	kSentryLevelDebug = 1,
+
+	kSentryLevelInfo = 2,
+
+	kSentryLevelWarning = 3,
+
+	kSentryLevelError = 4,
+
+	kSentryLevelFatal = 5
 }
 
 declare const enum SentryLogLevel {
 
-  kSentryLogLevelNone = 1,
+	kSentryLogLevelNone = 1,
 
-  kSentryLogLevelError = 2,
+	kSentryLogLevelError = 2,
 
-  kSentryLogLevelDebug = 3,
+	kSentryLogLevelDebug = 3,
 
-  kSentryLogLevelVerbose = 4
+	kSentryLogLevelVerbose = 4
 }
 
 declare class SentryMechanism extends NSObject implements SentrySerializable {
 
-  static alloc(): SentryMechanism; // inherited from NSObject
+	static alloc(): SentryMechanism; // inherited from NSObject
 
-  static new(): SentryMechanism; // inherited from NSObject
+	static new(): SentryMechanism; // inherited from NSObject
 
-  data: NSDictionary<string, any>;
+	data: NSDictionary<string, any>;
 
-  desc: string;
+	desc: string;
 
-  handled: number;
+	error: SentryNSError;
 
-  helpLink: string;
+	handled: number;
 
-  meta: NSDictionary<string, string>;
+	helpLink: string;
 
-  type: string;
+	meta: NSDictionary<string, string>;
 
-  readonly debugDescription: string; // inherited from NSObjectProtocol
+	type: string;
 
-  readonly description: string; // inherited from NSObjectProtocol
+	readonly debugDescription: string; // inherited from NSObjectProtocol
 
-  readonly hash: number; // inherited from NSObjectProtocol
+	readonly description: string; // inherited from NSObjectProtocol
 
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
+	readonly hash: number; // inherited from NSObjectProtocol
 
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
+	readonly isProxy: boolean; // inherited from NSObjectProtocol
 
-  readonly  // inherited from NSObjectProtocol
+	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
 
-  constructor(o: { type: string; });
+	readonly  // inherited from NSObjectProtocol
 
-  class(): typeof NSObject;
+	constructor(o: { type: string; });
 
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
+	class(): typeof NSObject;
 
-  initWithType(type: string): this;
+	conformsToProtocol(aProtocol: any /* Protocol */): boolean;
 
-  isEqual(object: any): boolean;
+	initWithType(type: string): this;
 
-  isKindOfClass(aClass: typeof NSObject): boolean;
+	isEqual(object: any): boolean;
 
-  isMemberOfClass(aClass: typeof NSObject): boolean;
+	isKindOfClass(aClass: typeof NSObject): boolean;
 
-  performSelector(aSelector: string): any;
+	isMemberOfClass(aClass: typeof NSObject): boolean;
 
-  performSelectorWithObject(aSelector: string, object: any): any;
+	performSelector(aSelector: string): any;
 
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
+	performSelectorWithObject(aSelector: string, object: any): any;
 
-  respondsToSelector(aSelector: string): boolean;
+	performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
 
-  retainCount(): number;
+	respondsToSelector(aSelector: string): boolean;
 
-  self(): this;
+	retainCount(): number;
 
-  serialize(): NSDictionary<string, any>;
+	self(): this;
+
+	serialize(): NSDictionary<string, any>;
 }
 
-declare class SentryNSURLRequest extends NSMutableURLRequest {
+declare class SentryMessage extends NSObject implements SentrySerializable {
 
-  static alloc(): SentryNSURLRequest; // inherited from NSObject
+	static alloc(): SentryMessage; // inherited from NSObject
 
-  static new(): SentryNSURLRequest; // inherited from NSObject
+	static new(): SentryMessage; // inherited from NSObject
 
-  static requestWithURL(URL: NSURL): SentryNSURLRequest; // inherited from NSURLRequest
+	readonly formatted: string;
 
-  static requestWithURLCachePolicyTimeoutInterval(URL: NSURL, cachePolicy: NSURLRequestCachePolicy, timeoutInterval: number): SentryNSURLRequest; // inherited from NSURLRequest
+	message: string;
 
-  constructor(o: { storeRequestWithDsn: SentryDsn; andData: NSData; });
+	params: NSArray<string>;
 
-  constructor(o: { storeRequestWithDsn: SentryDsn; andEvent: SentryEvent; });
+	readonly debugDescription: string; // inherited from NSObjectProtocol
 
-  initStoreRequestWithDsnAndDataDidFailWithError(dsn: SentryDsn, data: NSData): this;
+	readonly description: string; // inherited from NSObjectProtocol
 
-  initStoreRequestWithDsnAndEventDidFailWithError(dsn: SentryDsn, event: SentryEvent): this;
+	readonly hash: number; // inherited from NSObjectProtocol
+
+	readonly isProxy: boolean; // inherited from NSObjectProtocol
+
+	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
+
+	readonly  // inherited from NSObjectProtocol
+
+	constructor(o: { formatted: string; });
+
+	class(): typeof NSObject;
+
+	conformsToProtocol(aProtocol: any /* Protocol */): boolean;
+
+	initWithFormatted(formatted: string): this;
+
+	isEqual(object: any): boolean;
+
+	isKindOfClass(aClass: typeof NSObject): boolean;
+
+	isMemberOfClass(aClass: typeof NSObject): boolean;
+
+	performSelector(aSelector: string): any;
+
+	performSelectorWithObject(aSelector: string, object: any): any;
+
+	performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
+
+	respondsToSelector(aSelector: string): boolean;
+
+	retainCount(): number;
+
+	self(): this;
+
+	serialize(): NSDictionary<string, any>;
+}
+
+declare class SentryNSError extends NSObject implements SentrySerializable {
+
+	static alloc(): SentryNSError; // inherited from NSObject
+
+	static new(): SentryNSError; // inherited from NSObject
+
+	code: number;
+
+	domain: string;
+
+	readonly debugDescription: string; // inherited from NSObjectProtocol
+
+	readonly description: string; // inherited from NSObjectProtocol
+
+	readonly hash: number; // inherited from NSObjectProtocol
+
+	readonly isProxy: boolean; // inherited from NSObjectProtocol
+
+	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
+
+	readonly  // inherited from NSObjectProtocol
+
+	constructor(o: { domain: string; code: number; });
+
+	class(): typeof NSObject;
+
+	conformsToProtocol(aProtocol: any /* Protocol */): boolean;
+
+	initWithDomainCode(domain: string, code: number): this;
+
+	isEqual(object: any): boolean;
+
+	isKindOfClass(aClass: typeof NSObject): boolean;
+
+	isMemberOfClass(aClass: typeof NSObject): boolean;
+
+	performSelector(aSelector: string): any;
+
+	performSelectorWithObject(aSelector: string, object: any): any;
+
+	performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
+
+	respondsToSelector(aSelector: string): boolean;
+
+	retainCount(): number;
+
+	self(): this;
+
+	serialize(): NSDictionary<string, any>;
 }
 
 declare class SentryOptions extends NSObject {
 
-  static alloc(): SentryOptions; // inherited from NSObject
+	static alloc(): SentryOptions; // inherited from NSObject
 
-  static new(): SentryOptions; // inherited from NSObject
+	static defaultIntegrations(): NSArray<string>;
 
-  dist: string;
+	static new(): SentryOptions; // inherited from NSObject
 
-  dsn: SentryDsn;
+	attachStacktrace: boolean;
 
-  enabled: number;
+	beforeBreadcrumb: (p1: SentryBreadcrumb) => SentryBreadcrumb;
 
-  environment: string;
+	beforeSend: (p1: SentryEvent) => SentryEvent;
 
-  releaseName: string;
+	debug: boolean;
 
-  constructor(o: { options: NSDictionary<string, any>; });
+	dist: string;
 
-  initWithOptionsDidFailWithError(options: NSDictionary<string, any>): this;
+	dsn: string;
+
+	enableAutoSessionTracking: boolean;
+
+	enabled: boolean;
+
+	environment: string;
+
+	integrations: NSArray<string>;
+
+	logLevel: SentryLogLevel;
+
+	maxAttachmentSize: number;
+
+	maxBreadcrumbs: number;
+
+	onCrashedLastRun: (p1: SentryEvent) => void;
+
+	parsedDsn: SentryDsn;
+
+	releaseName: string;
+
+	sampleRate: number;
+
+	readonly sdkInfo: SentrySdkInfo;
+
+	sendDefaultPii: boolean;
+
+	sessionTrackingIntervalMillis: number;
+
+	constructor(o: { dict: NSDictionary<string, any>; });
+
+	initWithDictDidFailWithError(options: NSDictionary<string, any>): this;
 }
 
-declare class SentryQueueableRequestManager extends NSObject implements SentryRequestManager {
+declare class SentrySDK extends NSObject {
 
-  static alloc(): SentryQueueableRequestManager; // inherited from NSObject
+	static addBreadcrumb(crumb: SentryBreadcrumb): void;
 
-  static new(): SentryQueueableRequestManager; // inherited from NSObject
+	static alloc(): SentrySDK; // inherited from NSObject
 
-  readonly ready: boolean; // inherited from SentryRequestManager
+	static captureError(error: NSError): SentryId;
 
-  constructor(o: { session: NSURLSession; }); // inherited from SentryRequestManager
+	static captureErrorWithScope(error: NSError, scope: SentryScope): SentryId;
 
-  addRequestCompletionHandler(request: NSURLRequest, completionHandler: (p1: NSHTTPURLResponse, p2: NSError) => void): void;
+	static captureErrorWithScopeBlock(error: NSError, block: (p1: SentryScope) => void): SentryId;
 
-  cancelAllOperations(): void;
+	static captureEvent(event: SentryEvent): SentryId;
 
-  initWithSession(session: NSURLSession): this;
+	static captureEventWithScope(event: SentryEvent, scope: SentryScope): SentryId;
+
+	static captureEventWithScopeBlock(event: SentryEvent, block: (p1: SentryScope) => void): SentryId;
+
+	static captureException(exception: NSException): SentryId;
+
+	static captureExceptionWithScope(exception: NSException, scope: SentryScope): SentryId;
+
+	static captureExceptionWithScopeBlock(exception: NSException, block: (p1: SentryScope) => void): SentryId;
+
+	static captureMessage(message: string): SentryId;
+
+	static captureMessageWithScope(message: string, scope: SentryScope): SentryId;
+
+	static captureMessageWithScopeBlock(message: string, block: (p1: SentryScope) => void): SentryId;
+
+	static captureUserFeedback(userFeedback: SentryUserFeedback): void;
+
+	static configureScope(callback: (p1: SentryScope) => void): void;
+
+	static crash(): void;
+
+	static currentHub(): SentryHub;
+
+	static new(): SentrySDK; // inherited from NSObject
+
+	static setCurrentHub(hub: SentryHub): void;
+
+	static setUser(user: SentryUser): void;
+
+	static startWithConfigureOptions(configureOptions: (p1: SentryOptions) => void): void;
+
+	static startWithOptions(optionsDict: NSDictionary<string, any>): void;
+
+	static startWithOptionsObject(options: SentryOptions): void;
+
+	static readonly crashedLastRun: boolean;
+
+	static logLevel: SentryLogLevel;
 }
 
-interface SentryRequestManager {
+declare class SentryScope extends NSObject implements SentrySerializable {
 
-  ready: boolean;
+	static alloc(): SentryScope; // inherited from NSObject
 
-  addRequestCompletionHandler(request: NSURLRequest, completionHandler: (p1: NSHTTPURLResponse, p2: NSError) => void): void;
+	static new(): SentryScope; // inherited from NSObject
 
-  cancelAllOperations(): void;
+	readonly debugDescription: string; // inherited from NSObjectProtocol
 
-  initWithSession?(session: NSURLSession): SentryRequestManager;
+	readonly description: string; // inherited from NSObjectProtocol
+
+	readonly hash: number; // inherited from NSObjectProtocol
+
+	readonly isProxy: boolean; // inherited from NSObjectProtocol
+
+	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
+
+	readonly  // inherited from NSObjectProtocol
+
+	constructor(o: { maxBreadcrumbs: number; });
+
+	constructor(o: { scope: SentryScope; });
+
+	addAttachment(attachment: SentryAttachment): void;
+
+	addBreadcrumb(crumb: SentryBreadcrumb): void;
+
+	applyToEventMaxBreadcrumb(event: SentryEvent, maxBreadcrumbs: number): SentryEvent;
+
+	applyToSession(session: SentrySession): void;
+
+	class(): typeof NSObject;
+
+	clear(): void;
+
+	clearBreadcrumbs(): void;
+
+	conformsToProtocol(aProtocol: any /* Protocol */): boolean;
+
+	initWithMaxBreadcrumbs(maxBreadcrumbs: number): this;
+
+	initWithScope(scope: SentryScope): this;
+
+	isEqual(object: any): boolean;
+
+	isKindOfClass(aClass: typeof NSObject): boolean;
+
+	isMemberOfClass(aClass: typeof NSObject): boolean;
+
+	performSelector(aSelector: string): any;
+
+	performSelectorWithObject(aSelector: string, object: any): any;
+
+	performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
+
+	removeContextForKey(key: string): void;
+
+	removeExtraForKey(key: string): void;
+
+	removeTagForKey(key: string): void;
+
+	respondsToSelector(aSelector: string): boolean;
+
+	retainCount(): number;
+
+	self(): this;
+
+	serialize(): NSDictionary<string, any>;
+
+	setContextValueForKey(value: NSDictionary<string, any>, key: string): void;
+
+	setDist(dist: string): void;
+
+	setEnvironment(environment: string): void;
+
+	setExtraValueForKey(value: any, key: string): void;
+
+	setExtras(extras: NSDictionary<string, any>): void;
+
+	setFingerprint(fingerprint: NSArray<string> | string[]): void;
+
+	setLevel(level: SentryLevel): void;
+
+	setTagValueForKey(value: string, key: string): void;
+
+	setTags(tags: NSDictionary<string, string>): void;
+
+	setUser(user: SentryUser): void;
 }
-declare var SentryRequestManager: {
 
-  prototype: SentryRequestManager;
-};
+declare class SentrySdkInfo extends NSObject implements SentrySerializable {
 
-declare class SentryRequestOperation extends SentryAsynchronousOperation {
+	static alloc(): SentrySdkInfo; // inherited from NSObject
 
-  static alloc(): SentryRequestOperation; // inherited from NSObject
+	static new(): SentrySdkInfo; // inherited from NSObject
 
-  static new(): SentryRequestOperation; // inherited from NSObject
+	readonly name: string;
 
-  constructor(o: { session: NSURLSession; request: NSURLRequest; completionHandler: (p1: NSHTTPURLResponse, p2: NSError) => void; });
+	readonly version: string;
 
-  initWithSessionRequestCompletionHandler(session: NSURLSession, request: NSURLRequest, completionHandler: (p1: NSHTTPURLResponse, p2: NSError) => void): this;
+	readonly debugDescription: string; // inherited from NSObjectProtocol
+
+	readonly description: string; // inherited from NSObjectProtocol
+
+	readonly hash: number; // inherited from NSObjectProtocol
+
+	readonly isProxy: boolean; // inherited from NSObjectProtocol
+
+	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
+
+	readonly  // inherited from NSObjectProtocol
+
+	constructor(o: { dict: NSDictionary<any, any>; });
+
+	constructor(o: { name: string; andVersion: string; });
+
+	class(): typeof NSObject;
+
+	conformsToProtocol(aProtocol: any /* Protocol */): boolean;
+
+	initWithDict(dict: NSDictionary<any, any>): this;
+
+	initWithNameAndVersion(name: string, version: string): this;
+
+	isEqual(object: any): boolean;
+
+	isKindOfClass(aClass: typeof NSObject): boolean;
+
+	isMemberOfClass(aClass: typeof NSObject): boolean;
+
+	performSelector(aSelector: string): any;
+
+	performSelectorWithObject(aSelector: string, object: any): any;
+
+	performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
+
+	respondsToSelector(aSelector: string): boolean;
+
+	retainCount(): number;
+
+	self(): this;
+
+	serialize(): NSDictionary<string, any>;
 }
 
 interface SentrySerializable extends NSObjectProtocol {
 
-  serialize(): NSDictionary<string, any>;
+	serialize(): NSDictionary<string, any>;
 }
 declare var SentrySerializable: {
 
-  prototype: SentrySerializable;
+	prototype: SentrySerializable;
 };
 
-declare const enum SentrySeverity {
+declare class SentrySession extends NSObject implements NSCopying, SentrySerializable {
 
-  kSentrySeverityFatal = 0,
+	static alloc(): SentrySession; // inherited from NSObject
 
-  kSentrySeverityError = 1,
+	static new(): SentrySession; // inherited from NSObject
 
-  kSentrySeverityWarning = 2,
+	readonly distinctId: string;
 
-  kSentrySeverityInfo = 3,
+	readonly duration: number;
 
-  kSentrySeverityDebug = 4
+	environment: string;
+
+	readonly errors: number;
+
+	readonly flagInit: number;
+
+	readonly releaseName: string;
+
+	readonly sequence: number;
+
+	readonly sessionId: NSUUID;
+
+	readonly started: Date;
+
+	readonly status: SentrySessionStatus;
+
+	readonly timestamp: Date;
+
+	user: SentryUser;
+
+	readonly debugDescription: string; // inherited from NSObjectProtocol
+
+	readonly description: string; // inherited from NSObjectProtocol
+
+	readonly hash: number; // inherited from NSObjectProtocol
+
+	readonly isProxy: boolean; // inherited from NSObjectProtocol
+
+	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
+
+	readonly  // inherited from NSObjectProtocol
+
+	constructor(o: { JSONObject: NSDictionary<any, any>; });
+
+	constructor(o: { releaseName: string; });
+
+	class(): typeof NSObject;
+
+	conformsToProtocol(aProtocol: any /* Protocol */): boolean;
+
+	copyWithZone(zone: interop.Pointer | interop.Reference<any>): any;
+
+	endSessionAbnormalWithTimestamp(timestamp: Date): void;
+
+	endSessionCrashedWithTimestamp(timestamp: Date): void;
+
+	endSessionExitedWithTimestamp(timestamp: Date): void;
+
+	incrementErrors(): void;
+
+	initWithJSONObject(jsonObject: NSDictionary<any, any>): this;
+
+	initWithReleaseName(releaseName: string): this;
+
+	isEqual(object: any): boolean;
+
+	isKindOfClass(aClass: typeof NSObject): boolean;
+
+	isMemberOfClass(aClass: typeof NSObject): boolean;
+
+	performSelector(aSelector: string): any;
+
+	performSelectorWithObject(aSelector: string, object: any): any;
+
+	performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
+
+	respondsToSelector(aSelector: string): boolean;
+
+	retainCount(): number;
+
+	self(): this;
+
+	serialize(): NSDictionary<string, any>;
+}
+
+declare const enum SentrySessionStatus {
+
+	kSentrySessionStatusOk = 0,
+
+	kSentrySessionStatusExited = 1,
+
+	kSentrySessionStatusCrashed = 2,
+
+	kSentrySessionStatusAbnormal = 3
 }
 
 declare class SentryStacktrace extends NSObject implements SentrySerializable {
 
-  static alloc(): SentryStacktrace; // inherited from NSObject
+	static alloc(): SentryStacktrace; // inherited from NSObject
 
-  static new(): SentryStacktrace; // inherited from NSObject
+	static new(): SentryStacktrace; // inherited from NSObject
 
-  frames: NSArray<SentryFrame>;
+	frames: NSArray<SentryFrame>;
 
-  registers: NSDictionary<string, string>;
+	registers: NSDictionary<string, string>;
 
-  readonly debugDescription: string; // inherited from NSObjectProtocol
+	readonly debugDescription: string; // inherited from NSObjectProtocol
 
-  readonly description: string; // inherited from NSObjectProtocol
+	readonly description: string; // inherited from NSObjectProtocol
 
-  readonly hash: number; // inherited from NSObjectProtocol
+	readonly hash: number; // inherited from NSObjectProtocol
 
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
+	readonly isProxy: boolean; // inherited from NSObjectProtocol
 
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
+	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
 
-  readonly  // inherited from NSObjectProtocol
+	readonly  // inherited from NSObjectProtocol
 
-  constructor(o: { frames: NSArray<SentryFrame> | SentryFrame[]; registers: NSDictionary<string, string>; });
+	constructor(o: { frames: NSArray<SentryFrame> | SentryFrame[]; registers: NSDictionary<string, string>; });
 
-  class(): typeof NSObject;
+	class(): typeof NSObject;
 
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
+	conformsToProtocol(aProtocol: any /* Protocol */): boolean;
 
-  fixDuplicateFrames(): void;
+	fixDuplicateFrames(): void;
 
-  initWithFramesRegisters(frames: NSArray<SentryFrame> | SentryFrame[], registers: NSDictionary<string, string>): this;
+	initWithFramesRegisters(frames: NSArray<SentryFrame> | SentryFrame[], registers: NSDictionary<string, string>): this;
 
-  isEqual(object: any): boolean;
+	isEqual(object: any): boolean;
 
-  isKindOfClass(aClass: typeof NSObject): boolean;
+	isKindOfClass(aClass: typeof NSObject): boolean;
 
-  isMemberOfClass(aClass: typeof NSObject): boolean;
+	isMemberOfClass(aClass: typeof NSObject): boolean;
 
-  performSelector(aSelector: string): any;
+	performSelector(aSelector: string): any;
 
-  performSelectorWithObject(aSelector: string, object: any): any;
+	performSelectorWithObject(aSelector: string, object: any): any;
 
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
+	performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
 
-  respondsToSelector(aSelector: string): boolean;
+	respondsToSelector(aSelector: string): boolean;
 
-  retainCount(): number;
+	retainCount(): number;
 
-  self(): this;
+	self(): this;
 
-  serialize(): NSDictionary<string, any>;
-}
-
-declare class SentrySwizzle extends NSObject {
-
-  static alloc(): SentrySwizzle; // inherited from NSObject
-
-  static new(): SentrySwizzle; // inherited from NSObject
-
-  static swizzleClassMethodInClassNewImpFactory(selector: string, classToSwizzle: typeof NSObject, factoryBlock: (p1: SentrySwizzleInfo) => any): void;
-
-  static swizzleInstanceMethodInClassNewImpFactoryModeKey(selector: string, classToSwizzle: typeof NSObject, factoryBlock: (p1: SentrySwizzleInfo) => any, mode: SentrySwizzleMode, key: interop.Pointer | interop.Reference<any>): boolean;
-}
-
-declare class SentrySwizzleInfo extends NSObject {
-
-  static alloc(): SentrySwizzleInfo; // inherited from NSObject
-
-  static new(): SentrySwizzleInfo; // inherited from NSObject
-
-  readonly selector: string;
-
-  getOriginalImplementation(): interop.FunctionReference<() => void>;
-}
-
-declare const enum SentrySwizzleMode {
-
-  Always = 0,
-
-  OncePerClass = 1,
-
-  OncePerClassAndSuperclasses = 2
+	serialize(): NSDictionary<string, any>;
 }
 
 declare class SentryThread extends NSObject implements SentrySerializable {
 
-  static alloc(): SentryThread; // inherited from NSObject
+	static alloc(): SentryThread; // inherited from NSObject
 
-  static new(): SentryThread; // inherited from NSObject
+	static new(): SentryThread; // inherited from NSObject
 
-  crashed: number;
+	crashed: number;
 
-  current: number;
+	current: number;
 
-  name: string;
+	name: string;
 
-  stacktrace: SentryStacktrace;
+	stacktrace: SentryStacktrace;
 
-  threadId: number;
+	threadId: number;
 
-  readonly debugDescription: string; // inherited from NSObjectProtocol
+	readonly debugDescription: string; // inherited from NSObjectProtocol
 
-  readonly description: string; // inherited from NSObjectProtocol
+	readonly description: string; // inherited from NSObjectProtocol
 
-  readonly hash: number; // inherited from NSObjectProtocol
+	readonly hash: number; // inherited from NSObjectProtocol
 
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
+	readonly isProxy: boolean; // inherited from NSObjectProtocol
 
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
+	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
 
-  readonly  // inherited from NSObjectProtocol
+	readonly  // inherited from NSObjectProtocol
 
-  constructor(o: { threadId: number; });
+	constructor(o: { threadId: number; });
 
-  class(): typeof NSObject;
+	class(): typeof NSObject;
 
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
+	conformsToProtocol(aProtocol: any /* Protocol */): boolean;
 
-  initWithThreadId(threadId: number): this;
+	initWithThreadId(threadId: number): this;
 
-  isEqual(object: any): boolean;
+	isEqual(object: any): boolean;
 
-  isKindOfClass(aClass: typeof NSObject): boolean;
+	isKindOfClass(aClass: typeof NSObject): boolean;
 
-  isMemberOfClass(aClass: typeof NSObject): boolean;
+	isMemberOfClass(aClass: typeof NSObject): boolean;
 
-  performSelector(aSelector: string): any;
+	performSelector(aSelector: string): any;
 
-  performSelectorWithObject(aSelector: string, object: any): any;
+	performSelectorWithObject(aSelector: string, object: any): any;
 
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
+	performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
 
-  respondsToSelector(aSelector: string): boolean;
+	respondsToSelector(aSelector: string): boolean;
 
-  retainCount(): number;
+	retainCount(): number;
 
-  self(): this;
+	self(): this;
 
-  serialize(): NSDictionary<string, any>;
+	serialize(): NSDictionary<string, any>;
 }
 
-declare class SentryUser extends NSObject implements SentrySerializable {
+declare class SentryUser extends NSObject implements NSCopying, SentrySerializable {
 
-  static alloc(): SentryUser; // inherited from NSObject
+	static alloc(): SentryUser; // inherited from NSObject
 
-  static new(): SentryUser; // inherited from NSObject
+	static new(): SentryUser; // inherited from NSObject
 
-  email: string;
+	data: NSDictionary<string, any>;
 
-  extra: NSDictionary<string, any>;
+	email: string;
 
-  userId: string;
+	ipAddress: string;
 
-  username: string;
+	userId: string;
 
-  readonly debugDescription: string; // inherited from NSObjectProtocol
+	username: string;
 
-  readonly description: string; // inherited from NSObjectProtocol
+	readonly debugDescription: string; // inherited from NSObjectProtocol
 
-  readonly hash: number; // inherited from NSObjectProtocol
+	readonly description: string; // inherited from NSObjectProtocol
 
-  readonly isProxy: boolean; // inherited from NSObjectProtocol
+	readonly hash: number; // inherited from NSObjectProtocol
 
-  readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
+	readonly isProxy: boolean; // inherited from NSObjectProtocol
 
-  readonly  // inherited from NSObjectProtocol
+	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
 
-  constructor(o: { userId: string; });
+	readonly  // inherited from NSObjectProtocol
 
-  class(): typeof NSObject;
+	constructor(o: { userId: string; });
 
-  conformsToProtocol(aProtocol: any /* Protocol */): boolean;
+	class(): typeof NSObject;
 
-  initWithUserId(userId: string): this;
+	conformsToProtocol(aProtocol: any /* Protocol */): boolean;
 
-  isEqual(object: any): boolean;
+	copyWithZone(zone: interop.Pointer | interop.Reference<any>): any;
 
-  isKindOfClass(aClass: typeof NSObject): boolean;
+	hash(): number;
 
-  isMemberOfClass(aClass: typeof NSObject): boolean;
+	initWithUserId(userId: string): this;
 
-  performSelector(aSelector: string): any;
+	isEqual(object: any): boolean;
 
-  performSelectorWithObject(aSelector: string, object: any): any;
+	isEqualToUser(user: SentryUser): boolean;
 
-  performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
+	isKindOfClass(aClass: typeof NSObject): boolean;
 
-  respondsToSelector(aSelector: string): boolean;
+	isMemberOfClass(aClass: typeof NSObject): boolean;
 
-  retainCount(): number;
+	performSelector(aSelector: string): any;
 
-  self(): this;
+	performSelectorWithObject(aSelector: string, object: any): any;
 
-  serialize(): NSDictionary<string, any>;
+	performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
+
+	respondsToSelector(aSelector: string): boolean;
+
+	retainCount(): number;
+
+	self(): this;
+
+	serialize(): NSDictionary<string, any>;
+}
+
+declare class SentryUserFeedback extends NSObject implements SentrySerializable {
+
+	static alloc(): SentryUserFeedback; // inherited from NSObject
+
+	static new(): SentryUserFeedback; // inherited from NSObject
+
+	comments: string;
+
+	email: string;
+
+	readonly eventId: SentryId;
+
+	name: string;
+
+	readonly debugDescription: string; // inherited from NSObjectProtocol
+
+	readonly description: string; // inherited from NSObjectProtocol
+
+	readonly hash: number; // inherited from NSObjectProtocol
+
+	readonly isProxy: boolean; // inherited from NSObjectProtocol
+
+	readonly superclass: typeof NSObject; // inherited from NSObjectProtocol
+
+	readonly  // inherited from NSObjectProtocol
+
+	constructor(o: { eventId: SentryId; });
+
+	class(): typeof NSObject;
+
+	conformsToProtocol(aProtocol: any /* Protocol */): boolean;
+
+	initWithEventId(eventId: SentryId): this;
+
+	isEqual(object: any): boolean;
+
+	isKindOfClass(aClass: typeof NSObject): boolean;
+
+	isMemberOfClass(aClass: typeof NSObject): boolean;
+
+	performSelector(aSelector: string): any;
+
+	performSelectorWithObject(aSelector: string, object: any): any;
+
+	performSelectorWithObjectWithObject(aSelector: string, object1: any, object2: any): any;
+
+	respondsToSelector(aSelector: string): boolean;
+
+	retainCount(): number;
+
+	self(): this;
+
+	serialize(): NSDictionary<string, any>;
 }
 
 declare var SentryVersionNumber: number;
@@ -1893,564 +1452,4 @@ declare var SentryVersionString: interop.Reference<number>;
 
 declare var SentryVersionStringVar: interop.Reference<number>;
 
-interface __CFArray {
-  _base: CFRuntimeBase;
-  _count: number;
-  _mutations: number;
-  _mutInProgress: number;
-  _store: interop.Pointer | interop.Reference<any>;
-}
-declare var __CFArray: interop.StructType<__CFArray>;
-
-interface __CFArrayBucket {
-  _item: interop.Pointer | interop.Reference<any>;
-}
-declare var __CFArrayBucket: interop.StructType<__CFArrayBucket>;
-
-interface __CFArrayDeque {
-  _leftIdx: number;
-  _capacity: number;
-}
-declare var __CFArrayDeque: interop.StructType<__CFArrayDeque>;
-
-interface __CFBasicHash {
-  base: CFRuntimeBase;
-  bits: { mutations: number; hash_style: number; keys_offset: number; counts_offset: number; counts_width: number; hashes_offset: number; strong_values: number; strong_keys: number; weak_values: number; weak_keys: number; int_values: number; int_keys: number; indirect_keys: number; used_buckets: number; deleted: number; num_buckets_idx: number; __kret: number; __vret: number; __krel: number; __vrel: number; __: number; null_rc: number; fast_grow: number; finalized: number; __kdes: number; __vdes: number; __kequ: number; __vequ: number; __khas: number; __kget: number; };
-  pointers: interop.Reference<interop.Pointer | interop.Reference<any>>;
-}
-declare var __CFBasicHash: interop.StructType<__CFBasicHash>;
-
-interface __CFBasicHashCallbacks {
-  retainValue: interop.FunctionReference<(p1: any, p2: number) => number>;
-  retainKey: interop.FunctionReference<(p1: any, p2: number) => number>;
-  releaseValue: interop.FunctionReference<(p1: any, p2: number) => void>;
-  releaseKey: interop.FunctionReference<(p1: any, p2: number) => void>;
-  equateValues: interop.FunctionReference<(p1: number, p2: number) => boolean>;
-  equateKeys: interop.FunctionReference<(p1: number, p2: number) => boolean>;
-  hashKey: interop.FunctionReference<(p1: number) => number>;
-  getIndirectKey: interop.FunctionReference<(p1: number) => number>;
-  copyValueDescription: interop.FunctionReference<(p1: number) => NSMutableString>;
-  copyKeyDescription: interop.FunctionReference<(p1: number) => NSMutableString>;
-}
-declare var __CFBasicHashCallbacks: interop.StructType<__CFBasicHashCallbacks>;
-
-interface __CFDate {
-  _cfisa: number;
-  _time: number;
-}
-declare var __CFDate: interop.StructType<__CFDate>;
-
-interface __CFNumber {
-  _base: CFRuntimeBase;
-  _pad: number;
-}
-declare var __CFNumber: interop.StructType<__CFNumber>;
-
-interface __CFURL {
-  _cfBase: CFRuntimeBase;
-  _flags: number;
-  _encoding: number;
-  _string: NSMutableString;
-  _base: NSURL;
-  _extra: interop.Pointer | interop.Reference<any>;
-  _resourceInfo: interop.Pointer | interop.Reference<any>;
-  _ranges: interop.Reference<CFRange>;
-}
-declare var __CFURL: interop.StructType<__CFURL>;
-
-interface __inline1 {
-  length: number;
-}
-declare var __inline1: interop.StructType<__inline1>;
-
-interface __notInlineImmutable1 {
-  buffer: interop.Pointer | interop.Reference<any>;
-  length: number;
-  contentsDeallocator: any;
-}
-declare var __notInlineImmutable1: interop.StructType<__notInlineImmutable1>;
-
-interface __notInlineImmutable2 {
-  buffer: interop.Pointer | interop.Reference<any>;
-  contentsDeallocator: any;
-}
-declare var __notInlineImmutable2: interop.StructType<__notInlineImmutable2>;
-
-interface __notInlineMutable {
-  buffer: interop.Pointer | interop.Reference<any>;
-  length: number;
-  capacity: number;
-  hasGap: number;
-  isFixedCapacity: number;
-  isExternalMutable: number;
-  capacityProvidedExternally: number;
-  desiredCapacity: number;
-  contentsAllocator: any;
-}
-declare var __notInlineMutable: interop.StructType<__notInlineMutable>;
-
-interface class_ro_t {
-  flags: number;
-  instanceStart: number;
-  instanceSize: number;
-  ivarLayout: string;
-  name: string;
-  baseMethodList: interop.Pointer | interop.Reference<method_list_t>;
-  baseProtocols: interop.Pointer | interop.Reference<protocol_list_t>;
-  ivars: interop.Pointer | interop.Reference<ivar_list_t>;
-  weakIvarLayout: string;
-  baseProperties: interop.Pointer | interop.Reference<property_list_t>;
-}
-declare var class_ro_t: interop.StructType<class_ro_t>;
-
-interface class_rw_t {
-  flags: number;
-  version: number;
-  ro: interop.Pointer | interop.Reference<class_ro_t>;
-  methods: method_list_t;
-  properties: property_list_t;
-  protocols: protocol_list_t;
-  firstSubclass: typeof NSObject;
-  nextSiblingClass: typeof NSObject;
-  demangledName: string;
-}
-declare var class_rw_t: interop.StructType<class_rw_t>;
-
-interface class_t {
-  isa: interop.Pointer | interop.Reference<class_t>;
-  superclass: interop.Pointer | interop.Reference<class_t>;
-  cache: interop.Pointer | interop.Reference<any>;
-  vtable: interop.Pointer | interop.Reference<interop.FunctionReference<() => void>>;
-  data_NEVER_USE: number;
-}
-declare var class_t: interop.StructType<class_t>;
-
-interface ivar_list_t {
-  entsizeAndFlags: number;
-  count: number;
-  first: ivar_t;
-}
-declare var ivar_list_t: interop.StructType<ivar_list_t>;
-
-interface ivar_t {
-  offset: interop.Pointer | interop.Reference<number>;
-  name: string;
-  type: string;
-  alignment_raw: number;
-  size: number;
-}
-declare var ivar_t: interop.StructType<ivar_t>;
-
-interface method_list_t {
-  entsizeAndFlags: number;
-  count: number;
-  first: method_t;
-}
-declare var method_list_t: interop.StructType<method_list_t>;
-
-interface method_t {
-  name: string;
-  types: string;
-  imp: interop.FunctionReference<() => void>;
-}
-declare var method_t: interop.StructType<method_t>;
-
-interface property_list_t {
-  entsizeAndFlags: number;
-  count: number;
-  first: property_t;
-}
-declare var property_list_t: interop.StructType<property_list_t>;
-
-interface property_t {
-  name: string;
-  attributes: string;
-}
-declare var property_t: interop.StructType<property_t>;
-
-interface protocol_list_t {
-  entsizeAndFlags: number;
-  count: number;
-  first: protocol_t;
-}
-declare var protocol_list_t: interop.StructType<protocol_list_t>;
-
-interface protocol_t {
-  isa: typeof NSObject;
-  mangledName: string;
-  protocols: interop.Pointer | interop.Reference<protocol_list_t>;
-  instanceMethods: interop.Pointer | interop.Reference<method_list_t>;
-  classMethods: interop.Pointer | interop.Reference<method_list_t>;
-  optionalInstanceMethods: interop.Pointer | interop.Reference<method_list_t>;
-  optionalClassMethods: interop.Pointer | interop.Reference<method_list_t>;
-  instanceProperties: interop.Pointer | interop.Reference<property_list_t>;
-  size: number;
-  flags: number;
-  extendedMethodTypes: interop.Pointer | interop.Reference<string>;
-  _demangledName: string;
-}
-declare var protocol_t: interop.StructType<protocol_t>;
-
-declare function sentrycrash_addUserReport(report: string | interop.Pointer | interop.Reference<any>, reportLength: number): number;
-
-declare function sentrycrash_deleteAllReports(): void;
-
-declare function sentrycrash_deleteReportWithID(reportID: number): void;
-
-declare function sentrycrash_getReportCount(): number;
-
-declare function sentrycrash_getReportIDs(reportIDs: interop.Pointer | interop.Reference<number>, count: number): number;
-
-declare function sentrycrash_install(appName: string | interop.Pointer | interop.Reference<any>, installPath: string | interop.Pointer | interop.Reference<any>): SentryCrashMonitorType;
-
-declare function sentrycrash_notifyAppActive(isActive: boolean): void;
-
-declare function sentrycrash_notifyAppCrash(): void;
-
-declare function sentrycrash_notifyAppInForeground(isInForeground: boolean): void;
-
-declare function sentrycrash_notifyAppTerminate(): void;
-
-declare function sentrycrash_readReport(reportID: number): string;
-
-declare function sentrycrash_reportUserException(name: string | interop.Pointer | interop.Reference<any>, reason: string | interop.Pointer | interop.Reference<any>, language: string | interop.Pointer | interop.Reference<any>, lineOfCode: string | interop.Pointer | interop.Reference<any>, stackTrace: string | interop.Pointer | interop.Reference<any>, logAllThreads: boolean, terminateProgram: boolean): void;
-
-declare function sentrycrash_setAddConsoleLogToReport(shouldAddConsoleLogToReport: boolean): void;
-
-declare function sentrycrash_setCrashNotifyCallback(onCrashNotify: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>) => void>): void;
-
-declare function sentrycrash_setDeadlockWatchdogInterval(deadlockWatchdogInterval: number): void;
-
-declare function sentrycrash_setDoNotIntrospectClasses(doNotIntrospectClasses: interop.Pointer | interop.Reference<string>, length: number): void;
-
-declare function sentrycrash_setIntrospectMemory(introspectMemory: boolean): void;
-
-declare function sentrycrash_setMaxReportCount(maxReportCount: number): void;
-
-declare function sentrycrash_setMonitoring(monitors: SentryCrashMonitorType): SentryCrashMonitorType;
-
-declare function sentrycrash_setPrintPreviousLog(shouldPrintPreviousLog: boolean): void;
-
-declare function sentrycrash_setUserInfoJSON(userInfoJSON: string | interop.Pointer | interop.Reference<any>): void;
-
-declare function sentrycrashccd_freeze(): void;
-
-declare function sentrycrashccd_getAllThreads(threadCount: interop.Pointer | interop.Reference<number>): interop.Pointer | interop.Reference<number>;
-
-declare function sentrycrashccd_getQueueName(thread: number): string;
-
-declare function sentrycrashccd_getThreadName(thread: number): string;
-
-declare function sentrycrashccd_init(pollingIntervalInSeconds: number): void;
-
-declare function sentrycrashccd_unfreeze(): void;
-
-declare function sentrycrashcm_getActiveMonitors(): SentryCrashMonitorType;
-
-declare function sentrycrashcm_notifyFatalExceptionCaptured(isAsyncSafeEnvironment: boolean): boolean;
-
-declare function sentrycrashcm_reportUserException(name: string | interop.Pointer | interop.Reference<any>, reason: string | interop.Pointer | interop.Reference<any>, language: string | interop.Pointer | interop.Reference<any>, lineOfCode: string | interop.Pointer | interop.Reference<any>, stackTrace: string | interop.Pointer | interop.Reference<any>, logAllThreads: boolean, terminateProgram: boolean): void;
-
-declare function sentrycrashcm_setActiveMonitors(monitorTypes: SentryCrashMonitorType): void;
-
-declare function sentrycrashcm_setDeadlockHandlerWatchdogInterval(value: number): void;
-
-declare function sentrycrashcpu_currentArch(): string;
-
-declare function sentrycrashcpu_exceptionRegisterName(regNumber: number): string;
-
-declare function sentrycrashcpu_i_fillState(thread: number, state: interop.Pointer | interop.Reference<number>, flavor: number, stateCount: number): boolean;
-
-declare function sentrycrashcpu_normaliseInstructionPointer(ip: number): number;
-
-declare function sentrycrashcpu_numExceptionRegisters(): number;
-
-declare function sentrycrashcpu_numRegisters(): number;
-
-declare function sentrycrashcpu_registerName(regNumber: number): string;
-
-declare function sentrycrashcpu_stackGrowDirection(): number;
-
-declare function sentrycrashcrf_fixupCrashReport(crashReport: string | interop.Pointer | interop.Reference<any>): string;
-
-declare function sentrycrashcrs_addUserReport(report: string | interop.Pointer | interop.Reference<any>, reportLength: number): number;
-
-declare function sentrycrashcrs_deleteAllReports(): void;
-
-declare function sentrycrashcrs_deleteReportWithID(reportID: number): void;
-
-declare function sentrycrashcrs_getNextCrashReportPath(crashReportPathBuffer: string | interop.Pointer | interop.Reference<any>): void;
-
-declare function sentrycrashcrs_getReportCount(): number;
-
-declare function sentrycrashcrs_getReportIDs(reportIDs: interop.Pointer | interop.Reference<number>, count: number): number;
-
-declare function sentrycrashcrs_initialize(appName: string | interop.Pointer | interop.Reference<any>, reportsPath: string | interop.Pointer | interop.Reference<any>): void;
-
-declare function sentrycrashcrs_readReport(reportID: number): string;
-
-declare function sentrycrashcrs_setMaxReportCount(maxReportCount: number): void;
-
-declare function sentrycrashdate_utcStringFromTimestamp(timestamp: number, buffer21Chars: string | interop.Pointer | interop.Reference<any>): void;
-
-declare function sentrycrashdebug_isBeingTraced(): boolean;
-
-declare function sentrycrashdl_dladdr(address: number, info: interop.Pointer | interop.Reference<Dl_info>): boolean;
-
-declare function sentrycrashdl_getBinaryImage(index: number, buffer: interop.Pointer | interop.Reference<SentryCrashBinaryImage>): boolean;
-
-declare function sentrycrashdl_imageCount(): number;
-
-declare function sentrycrashdl_imageNamed(imageName: string | interop.Pointer | interop.Reference<any>, exactMatch: boolean): number;
-
-declare function sentrycrashdl_imageUUID(imageName: string | interop.Pointer | interop.Reference<any>, exactMatch: boolean): string;
-
-declare function sentrycrashfu_closeBufferedReader(reader: interop.Pointer | interop.Reference<SentryCrashBufferedReader>): void;
-
-declare function sentrycrashfu_closeBufferedWriter(writer: interop.Pointer | interop.Reference<SentryCrashBufferedWriter>): void;
-
-declare function sentrycrashfu_deleteContentsOfPath(path: string | interop.Pointer | interop.Reference<any>): boolean;
-
-declare function sentrycrashfu_flushBufferedWriter(writer: interop.Pointer | interop.Reference<SentryCrashBufferedWriter>): boolean;
-
-declare function sentrycrashfu_lastPathEntry(path: string | interop.Pointer | interop.Reference<any>): string;
-
-declare function sentrycrashfu_makePath(absolutePath: string | interop.Pointer | interop.Reference<any>): boolean;
-
-declare function sentrycrashfu_openBufferedReader(reader: interop.Pointer | interop.Reference<SentryCrashBufferedReader>, path: string | interop.Pointer | interop.Reference<any>, readBuffer: string | interop.Pointer | interop.Reference<any>, readBufferLength: number): boolean;
-
-declare function sentrycrashfu_openBufferedWriter(writer: interop.Pointer | interop.Reference<SentryCrashBufferedWriter>, path: string | interop.Pointer | interop.Reference<any>, writeBuffer: string | interop.Pointer | interop.Reference<any>, writeBufferLength: number): boolean;
-
-declare function sentrycrashfu_readBufferedReader(reader: interop.Pointer | interop.Reference<SentryCrashBufferedReader>, dstBuffer: string | interop.Pointer | interop.Reference<any>, byteCount: number): number;
-
-declare function sentrycrashfu_readBufferedReaderUntilChar(reader: interop.Pointer | interop.Reference<SentryCrashBufferedReader>, ch: number, dstBuffer: string | interop.Pointer | interop.Reference<any>, length: interop.Pointer | interop.Reference<number>): boolean;
-
-declare function sentrycrashfu_readBytesFromFD(fd: number, bytes: string | interop.Pointer | interop.Reference<any>, length: number): boolean;
-
-declare function sentrycrashfu_readEntireFile(path: string | interop.Pointer | interop.Reference<any>, data: interop.Pointer | interop.Reference<string>, length: interop.Pointer | interop.Reference<number>, maxLength: number): boolean;
-
-declare function sentrycrashfu_readLineFromFD(fd: number, buffer: string | interop.Pointer | interop.Reference<any>, maxLength: number): number;
-
-declare function sentrycrashfu_removeFile(path: string | interop.Pointer | interop.Reference<any>, mustExist: boolean): boolean;
-
-declare function sentrycrashfu_writeBufferedWriter(writer: interop.Pointer | interop.Reference<SentryCrashBufferedWriter>, data: string | interop.Pointer | interop.Reference<any>, length: number): boolean;
-
-declare function sentrycrashfu_writeBytesToFD(fd: number, bytes: string | interop.Pointer | interop.Reference<any>, length: number): boolean;
-
-declare function sentrycrashfu_writeStringToFD(fd: number, string: string | interop.Pointer | interop.Reference<any>): boolean;
-
-declare function sentrycrashid_generate(destinationBuffer37Bytes: string | interop.Pointer | interop.Reference<any>): void;
-
-declare function sentrycrashjson_addBooleanElement(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, name: string | interop.Pointer | interop.Reference<any>, value: boolean): number;
-
-declare function sentrycrashjson_addDataElement(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, name: string | interop.Pointer | interop.Reference<any>, value: string | interop.Pointer | interop.Reference<any>, length: number): number;
-
-declare function sentrycrashjson_addFloatingPointElement(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, name: string | interop.Pointer | interop.Reference<any>, value: number): number;
-
-declare function sentrycrashjson_addIntegerElement(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, name: string | interop.Pointer | interop.Reference<any>, value: number): number;
-
-declare function sentrycrashjson_addJSONElement(encodeContext: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, name: string | interop.Pointer | interop.Reference<any>, jsonData: string | interop.Pointer | interop.Reference<any>, jsonDataLength: number, closeLastContainer: boolean): number;
-
-declare function sentrycrashjson_addJSONFromFile(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, name: string | interop.Pointer | interop.Reference<any>, filename: string | interop.Pointer | interop.Reference<any>, closeLastContainer: boolean): number;
-
-declare function sentrycrashjson_addNullElement(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, name: string | interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashjson_addRawJSONData(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, data: string | interop.Pointer | interop.Reference<any>, length: number): number;
-
-declare function sentrycrashjson_addStringElement(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, name: string | interop.Pointer | interop.Reference<any>, value: string | interop.Pointer | interop.Reference<any>, length: number): number;
-
-declare function sentrycrashjson_appendDataElement(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, value: string | interop.Pointer | interop.Reference<any>, length: number): number;
-
-declare function sentrycrashjson_appendStringElement(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, value: string | interop.Pointer | interop.Reference<any>, length: number): number;
-
-declare function sentrycrashjson_beginArray(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, name: string | interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashjson_beginDataElement(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, name: string | interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashjson_beginElement(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, name: string | interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashjson_beginEncode(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, prettyPrint: boolean, addJSONData: interop.FunctionReference<(p1: string, p2: number, p3: interop.Pointer | interop.Reference<any>) => number>, userData: interop.Pointer | interop.Reference<any>): void;
-
-declare function sentrycrashjson_beginObject(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, name: string | interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashjson_beginStringElement(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>, name: string | interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashjson_decode(data: string | interop.Pointer | interop.Reference<any>, length: number, stringBuffer: string | interop.Pointer | interop.Reference<any>, stringBufferLength: number, callbacks: interop.Pointer | interop.Reference<SentryCrashJSONDecodeCallbacks>, userData: interop.Pointer | interop.Reference<any>, errorOffset: interop.Pointer | interop.Reference<number>): number;
-
-declare function sentrycrashjson_endContainer(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>): number;
-
-declare function sentrycrashjson_endDataElement(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>): number;
-
-declare function sentrycrashjson_endEncode(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>): number;
-
-declare function sentrycrashjson_endStringElement(context: interop.Pointer | interop.Reference<SentryCrashJSONEncodeContext>): number;
-
-declare function sentrycrashjson_stringForError(error: number): string;
-
-declare function sentrycrashlog_clearLogFile(): boolean;
-
-declare function sentrycrashlog_setLogFilename(filename: string | interop.Pointer | interop.Reference<any>, overwrite: boolean): boolean;
-
-declare function sentrycrashmach_exceptionName(exceptionType: number): string;
-
-declare function sentrycrashmach_kernelReturnCodeName(returnCode: number): string;
-
-declare function sentrycrashmach_machExceptionForSignal(signal: number): number;
-
-declare function sentrycrashmach_signalForMachException(exception: number, code: number): number;
-
-declare function sentrycrashmc_addReservedThread(thread: number): void;
-
-declare function sentrycrashmc_contextSize(): number;
-
-declare function sentrycrashmc_resumeEnvironment(): void;
-
-declare function sentrycrashmc_suspendEnvironment(): void;
-
-declare function sentrycrashmem_copyMaxPossible(src: interop.Pointer | interop.Reference<any>, dst: interop.Pointer | interop.Reference<any>, byteCount: number): number;
-
-declare function sentrycrashmem_copySafely(src: interop.Pointer | interop.Reference<any>, dst: interop.Pointer | interop.Reference<any>, byteCount: number): boolean;
-
-declare function sentrycrashmem_isMemoryReadable(memory: interop.Pointer | interop.Reference<any>, byteCount: number): boolean;
-
-declare function sentrycrashmem_maxReadableBytes(memory: interop.Pointer | interop.Reference<any>, tryByteCount: number): number;
-
-declare function sentrycrashmonitortype_name(monitorType: SentryCrashMonitorType): string;
-
-declare function sentrycrashobjc_arrayContents(arrayPtr: interop.Pointer | interop.Reference<any>, contents: interop.Pointer | interop.Reference<number>, count: number): number;
-
-declare function sentrycrashobjc_arrayCount(arrayPtr: interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashobjc_baseClass(classPtr: interop.Pointer | interop.Reference<any>): interop.Pointer | interop.Reference<any>;
-
-declare function sentrycrashobjc_className(classPtr: interop.Pointer | interop.Reference<any>): string;
-
-declare function sentrycrashobjc_copyStringContents(string: interop.Pointer | interop.Reference<any>, dst: string | interop.Pointer | interop.Reference<any>, maxLength: number): number;
-
-declare function sentrycrashobjc_copyURLContents(nsurl: interop.Pointer | interop.Reference<any>, dst: string | interop.Pointer | interop.Reference<any>, maxLength: number): number;
-
-declare function sentrycrashobjc_dateContents(datePtr: interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashobjc_dictionaryCount(dict: interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashobjc_dictionaryFirstEntry(dict: interop.Pointer | interop.Reference<any>, key: interop.Pointer | interop.Reference<number>, value: interop.Pointer | interop.Reference<number>): boolean;
-
-declare function sentrycrashobjc_getDescription(object: interop.Pointer | interop.Reference<any>, buffer: string | interop.Pointer | interop.Reference<any>, bufferLength: number): number;
-
-declare function sentrycrashobjc_isClassNamed(classPtr: interop.Pointer | interop.Reference<any>, className: string | interop.Pointer | interop.Reference<any>): boolean;
-
-declare function sentrycrashobjc_isKindOfClass(classPtr: interop.Pointer | interop.Reference<any>, className: string | interop.Pointer | interop.Reference<any>): boolean;
-
-declare function sentrycrashobjc_isMetaClass(classPtr: interop.Pointer | interop.Reference<any>): boolean;
-
-declare function sentrycrashobjc_isRootClass(classPtr: interop.Pointer | interop.Reference<any>): boolean;
-
-declare function sentrycrashobjc_isTaggedPointer(pointer: interop.Pointer | interop.Reference<any>): boolean;
-
-declare function sentrycrashobjc_isValidObject(object: interop.Pointer | interop.Reference<any>): boolean;
-
-declare function sentrycrashobjc_isValidTaggedPointer(pointer: interop.Pointer | interop.Reference<any>): boolean;
-
-declare function sentrycrashobjc_isaPointer(objectOrClassPtr: interop.Pointer | interop.Reference<any>): interop.Pointer | interop.Reference<any>;
-
-declare function sentrycrashobjc_ivarCount(classPtr: interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashobjc_ivarList(classPtr: interop.Pointer | interop.Reference<any>, dstIvars: interop.Pointer | interop.Reference<SentryCrashObjCIvar>, ivarsCount: number): number;
-
-declare function sentrycrashobjc_ivarNamed(classPtr: interop.Pointer | interop.Reference<any>, name: string | interop.Pointer | interop.Reference<any>, dst: interop.Pointer | interop.Reference<SentryCrashObjCIvar>): boolean;
-
-declare function sentrycrashobjc_ivarValue(objectPtr: interop.Pointer | interop.Reference<any>, ivarIndex: number, dst: interop.Pointer | interop.Reference<any>): boolean;
-
-declare function sentrycrashobjc_numberAsFloat(object: interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashobjc_numberAsInteger(object: interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashobjc_numberIsFloat(object: interop.Pointer | interop.Reference<any>): boolean;
-
-declare function sentrycrashobjc_objectClassName(objectPtr: interop.Pointer | interop.Reference<any>): string;
-
-declare function sentrycrashobjc_objectClassType(object: interop.Pointer | interop.Reference<any>): SentryCrashObjCClassType;
-
-declare function sentrycrashobjc_objectType(objectOrClassPtr: interop.Pointer | interop.Reference<any>): SentryCrashObjCType;
-
-declare function sentrycrashobjc_stringLength(stringPtr: interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashobjc_superClass(classPtr: interop.Pointer | interop.Reference<any>): interop.Pointer | interop.Reference<any>;
-
-declare function sentrycrashobjc_taggedPointerPayload(taggedObjectPtr: interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashreport_setDoNotIntrospectClasses(doNotIntrospectClasses: interop.Pointer | interop.Reference<string>, length: number): void;
-
-declare function sentrycrashreport_setIntrospectMemory(shouldIntrospectMemory: boolean): void;
-
-declare function sentrycrashreport_setUserInfoJSON(userInfoJSON: string | interop.Pointer | interop.Reference<any>): void;
-
-declare function sentrycrashreport_setUserSectionWriteCallback(userSectionWriteCallback: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashReportWriter>) => void>): void;
-
-declare function sentrycrashsc_initCursor(cursor: interop.Pointer | interop.Reference<SentryCrashStackCursor>, resetCursor: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashStackCursor>) => void>, advanceCursor: interop.FunctionReference<(p1: interop.Pointer | interop.Reference<SentryCrashStackCursor>) => boolean>): void;
-
-declare function sentrycrashsc_initSelfThread(cursor: interop.Pointer | interop.Reference<SentryCrashStackCursor>, skipEntries: number): void;
-
-declare function sentrycrashsc_initWithBacktrace(cursor: interop.Pointer | interop.Reference<SentryCrashStackCursor>, backtrace: interop.Pointer | interop.Reference<number>, backtraceLength: number, skipEntries: number): void;
-
-declare function sentrycrashsc_resetCursor(cursor: interop.Pointer | interop.Reference<SentryCrashStackCursor>): void;
-
-declare function sentrycrashsignal_fatalSignals(): interop.Pointer | interop.Reference<number>;
-
-declare function sentrycrashsignal_numFatalSignals(): number;
-
-declare function sentrycrashsignal_signalCodeName(signal: number, code: number): string;
-
-declare function sentrycrashsignal_signalName(signal: number): string;
-
-declare function sentrycrashstate_currentState(): interop.Pointer | interop.Reference<SentryCrash_AppState>;
-
-declare function sentrycrashstate_initialize(stateFilePath: string | interop.Pointer | interop.Reference<any>): void;
-
-declare function sentrycrashstate_notifyAppActive(isActive: boolean): void;
-
-declare function sentrycrashstate_notifyAppCrash(): void;
-
-declare function sentrycrashstate_notifyAppInForeground(isInForeground: boolean): void;
-
-declare function sentrycrashstate_notifyAppTerminate(): void;
-
-declare function sentrycrashstate_reset(): boolean;
-
-declare function sentrycrashstring_extractHexValue(string: string | interop.Pointer | interop.Reference<any>, stringLength: number, result: interop.Pointer | interop.Reference<number>): boolean;
-
-declare function sentrycrashstring_isNullTerminatedUTF8String(memory: interop.Pointer | interop.Reference<any>, minLength: number, maxLength: number): boolean;
-
-declare function sentrycrashsymbolicator_symbolicate(cursor: interop.Pointer | interop.Reference<SentryCrashStackCursor>): boolean;
-
-declare function sentrycrashsysctl_getMacAddress(name: string | interop.Pointer | interop.Reference<any>, macAddressBuffer: string | interop.Pointer | interop.Reference<any>): boolean;
-
-declare function sentrycrashsysctl_int32(major_cmd: number, minor_cmd: number): number;
-
-declare function sentrycrashsysctl_int32ForName(name: string | interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashsysctl_int64(major_cmd: number, minor_cmd: number): number;
-
-declare function sentrycrashsysctl_int64ForName(name: string | interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashsysctl_string(major_cmd: number, minor_cmd: number, value: string | interop.Pointer | interop.Reference<any>, maxSize: number): number;
-
-declare function sentrycrashsysctl_stringForName(name: string | interop.Pointer | interop.Reference<any>, value: string | interop.Pointer | interop.Reference<any>, maxSize: number): number;
-
-declare function sentrycrashsysctl_timeval(major_cmd: number, minor_cmd: number): timeval;
-
-declare function sentrycrashsysctl_timevalForName(name: string | interop.Pointer | interop.Reference<any>): timeval;
-
-declare function sentrycrashsysctl_uint32(major_cmd: number, minor_cmd: number): number;
-
-declare function sentrycrashsysctl_uint32ForName(name: string | interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashsysctl_uint64(major_cmd: number, minor_cmd: number): number;
-
-declare function sentrycrashsysctl_uint64ForName(name: string | interop.Pointer | interop.Reference<any>): number;
-
-declare function sentrycrashthread_getThreadName(thread: number, buffer: string | interop.Pointer | interop.Reference<any>, bufLength: number): boolean;
-
-declare function sentrycrashthread_self(): number;
-
-declare function sentrycrashzombie_className(object: interop.Pointer | interop.Reference<any>): string;
+declare var defaultMaxBreadcrumbs: number;


### PR DESCRIPTION

## What is the current behavior?

- The current package relies on outdated versions of the Sentry SDK.  
- When using this package on Android consumers have to set the DSN in AndroidManifest instead of using Sentry.init
- It is not possible to set environment or release in the init method like other implementations of Sentry allow.
- Sentry.clearContext does nothing on Android
- The existing setContextUser, setContextTags, setContextExtra methods do not match the Sentry SDK's naming of setUser, setTags & setExtras


## What is the new behavior?

- Updated to the latest available versions of Sentry for Android and iOS.
- Sentry.init now works for Android which makes the usage of this package the same on iOS as it is on Android again.  This changes what Android consumers should put in their AndroidManifest, which has been updated in the README.
- Added a new initWithOptions method that allows the setting of dsn, environment and release via a config object.
- Sentry.clearContext on Android now works.
- Deprecated setContextUser, setContextTags & setContextExtra and added setUser, setTags & setExtras to match Sentry's naming.

BREAKING CHANGES:

I tried to not have any breaking changes which is why initWithOptions was added instead of just replacing init with it.   If you're not opposed to a breaking change I would suggest doing that so that the init method is consistent with other Sentry sdk's.

